### PR TITLE
Add whisper engine, Developer ID signing, and UI polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@
 .DS_Store
 KeyScribe.app/
 dist/
+Vendor/Whisper/
+
+# Local build script (contains signing identity)
+build-local.sh
+
+# Code signing
+*.cer
+*.key
+*.csr
+*.certSigningRequest
+*.p12

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "KeyScribe",
     platforms: [
-        .macOS("13.0")
+        .macOS("13.3")
     ],
     products: [
         .executable(name: "KeyScribe", targets: ["KeyScribe"])
@@ -12,8 +12,15 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "KeyScribe",
+            dependencies: [
+                "whisper"
+            ],
             path: "Sources/KeyScribe",
             resources: [.process("../../Resources")]
+        ),
+        .binaryTarget(
+            name: "whisper",
+            path: "Vendor/Whisper/whisper.xcframework"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -6,11 +6,23 @@ The app runs as a menu bar utility (`LSUIElement`), so it does not show a Dock i
 
 ## What the app does
 
-- Captures speech using Apple Speech (`SFSpeechRecognizer`) and microphone input.
+- Captures speech with a selectable transcription engine:
+  - Apple Speech (`SFSpeechRecognizer`)
+  - whisper.cpp (on-device models)
 - Cleans transcript text before insert (spacing, punctuation, capitalization, duplicate-word cleanup).
 - Inserts text into the active app with reliability fallbacks.
 - Stores the last 20 transcripts in local history.
 - Lets you paste the most recent transcript with `⌥⌘V` without needing to copy from history first.
+
+## Transcription engines
+
+- **Apple Speech**:
+  - Works out of the box once permissions are granted.
+  - Supports local/cloud recognition mode options.
+- **whisper.cpp**:
+  - Runs on-device using downloaded model files (`tiny.en`, `base.en`, `small.en`).
+  - Model downloads are explicit user actions in Settings (no background model downloads).
+  - If whisper is selected and no model is installed, dictation is blocked until a model is installed.
 
 ## How insertion works
 
@@ -40,8 +52,9 @@ KeyScribe is a fully functional macOS transcription assistant ready for daily us
 
 - Default hold-to-talk shortcut: **⌥⌘Space** (customizable in Settings)
 - Default continuous toggle shortcut: **⌃⌥⌘Space** (customizable in Settings)
-- Requires **Accessibility**, **Microphone**, and **Speech Recognition** permissions (prompted on first launch)
-- Tested on macOS 13 (Ventura) and later
+- Requires **Accessibility** and **Microphone** permissions
+- **Speech Recognition** permission is required only when Apple Speech engine is selected
+- Tested on macOS 13.3 and later
 
 ### Reset Accessibility permission (dev/testing)
 
@@ -85,6 +98,8 @@ Build app + drag-and-drop DMG:
 ```bash
 ./build.sh
 ```
+
+`build.sh` will auto-fetch `whisper.xcframework` into `Vendor/Whisper/` if it is missing.
 
 Output artifacts:
 
@@ -139,8 +154,13 @@ Scripts/run-insertion-reliability.sh --regression
 
 - `Package.swift` - Swift package entry
 - `Sources/KeyScribe/App.swift` - app lifecycle, status menu, permission flow, icon state, insertion orchestration
-- `Sources/KeyScribe/Services/SpeechTranscriber.swift` - speech capture + recognition pipeline
+- `Sources/KeyScribe/Services/SpeechTranscriber.swift` - transcription engine router
+- `Sources/KeyScribe/Services/AppleSpeechTranscriber.swift` - Apple Speech capture + recognition pipeline
+- `Sources/KeyScribe/Services/WhisperTranscriber.swift` - whisper.cpp capture + transcription pipeline
+- `Sources/KeyScribe/Services/WhisperModelCatalog.swift` - curated whisper model metadata
+- `Sources/KeyScribe/Services/WhisperModelManager.swift` - model download/install/delete lifecycle
 - `Sources/KeyScribe/Services/TextInserter.swift` - insertion engine and paste/typing fallbacks
 - `Sources/KeyScribe/Services/HotkeyManager.swift` - hold-to-talk and one-shot hotkeys
 - `Sources/KeyScribe/Services/TranscriptHistoryStore.swift` - local transcript history persistence
 - `Resources/Info.plist` - app metadata and permission keys
+- `Scripts/update-whisper-framework.sh` - helper script to fetch/update local whisper XCFramework

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
         <key>NSSpeechRecognitionUsageDescription</key>
         <string>KeyScribe uses speech recognition so you can transcribe while holding the shortcut.</string>
         <key>LSMinimumSystemVersion</key>
-        <string>13.0</string>
+        <string>13.3</string>
         <key>CFBundleIconFile</key>
         <string>AppIcon</string>
         <key>NSHighResolutionCapable</key>

--- a/Resources/KeyScribe.entitlements
+++ b/Resources/KeyScribe.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/Scripts/SettingsStoreWhisperSmokeTests.swift
+++ b/Scripts/SettingsStoreWhisperSmokeTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+@inline(__always)
+func check(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("❌ \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+@main
+struct SettingsStoreWhisperSmokeTests {
+    static func main() async {
+        let settings = await MainActor.run { SettingsStore.shared }
+
+        let originalEngine = await MainActor.run { settings.transcriptionEngineRawValue }
+        let originalModelID = await MainActor.run { settings.selectedWhisperModelID }
+        let originalUseCoreML = await MainActor.run { settings.whisperUseCoreML }
+
+        await MainActor.run {
+            check(TranscriptionEngineType(rawValue: settings.transcriptionEngineRawValue) != nil, "Default engine should be valid")
+
+            settings.transcriptionEngine = .whisperCpp
+            settings.selectedWhisperModelID = "tiny.en"
+            settings.whisperUseCoreML = false
+
+            check(settings.transcriptionEngine == .whisperCpp, "Engine setter should persist whisper.cpp")
+            check(settings.selectedWhisperModelID == "tiny.en", "Selected whisper model should persist")
+            check(settings.whisperUseCoreML == false, "Core ML toggle should persist")
+
+            let defaults = UserDefaults.standard
+            check(
+                defaults.string(forKey: "KeyScribe.transcriptionEngine") == TranscriptionEngineType.whisperCpp.rawValue,
+                "Engine key should be saved in UserDefaults"
+            )
+            check(
+                defaults.string(forKey: "KeyScribe.selectedWhisperModelID") == "tiny.en",
+                "Selected model key should be saved in UserDefaults"
+            )
+            check(
+                defaults.bool(forKey: "KeyScribe.whisperUseCoreML") == false,
+                "Core ML key should be saved in UserDefaults"
+            )
+
+            settings.transcriptionEngineRawValue = "invalid-engine"
+            check(settings.transcriptionEngine == .appleSpeech, "Invalid engine raw value should fall back to Apple Speech")
+        }
+
+        await MainActor.run {
+            settings.transcriptionEngineRawValue = originalEngine
+            settings.selectedWhisperModelID = originalModelID
+            settings.whisperUseCoreML = originalUseCoreML
+        }
+
+        print("✅ Settings store whisper smoke tests passed")
+    }
+}

--- a/Scripts/WhisperCatalogSmokeTests.swift
+++ b/Scripts/WhisperCatalogSmokeTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@inline(__always)
+func check(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("❌ \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+@main
+struct WhisperCatalogSmokeTests {
+    static func main() {
+        let models = WhisperModelCatalog.curatedModels
+        check(!models.isEmpty, "Curated model list should not be empty")
+
+        let modelIDs = Set(models.map(\.id))
+        let expectedIDs = Set(WhisperModelCatalog.modelIDs)
+        check(modelIDs == expectedIDs, "Curated model IDs should match the catalog source list")
+        check(models.count >= 25, "Catalog should expose a full set of whisper models")
+        check(modelIDs.contains("medium.en"), "Catalog should include medium.en")
+        check(modelIDs.contains("large-v3"), "Catalog should include large-v3")
+        check(modelIDs.contains("large-v3-turbo"), "Catalog should include large-v3-turbo")
+
+        for model in models {
+            check(!model.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "Display name should not be empty")
+            check(!model.useCaseDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "Use-case text should not be empty")
+            check(model.ggmlDownloadURL.absoluteString.hasPrefix("https://"), "Model URL should use HTTPS")
+            if let sha1 = model.ggmlSHA1 {
+                check(sha1.count == 40, "SHA1 should be 40 hex chars for \(model.id)")
+            }
+
+            if let coreMLURL = model.coreMLDownloadURL {
+                check(coreMLURL.absoluteString.hasSuffix(".zip"), "Core ML URL should point to zip for \(model.id)")
+            }
+        }
+
+        print("✅ Whisper model catalog smoke tests passed")
+    }
+}

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+if [ ! -d "Vendor/Whisper/whisper.xcframework" ]; then
+  echo "whisper.xcframework not found, downloading framework..."
+  Scripts/update-whisper-framework.sh
+fi
+
 swiftc \
   Sources/KeyScribe/Services/ShortcutValidationRules.swift \
   Sources/KeyScribe/Services/DictationInputModeStateMachine.swift \
@@ -16,3 +21,21 @@ swiftc \
 
 /tmp/keyscribe-core-smoke-tests
 Scripts/run-insertion-reliability.sh --regression
+
+swiftc \
+  Sources/KeyScribe/Services/WhisperModelCatalog.swift \
+  Scripts/WhisperCatalogSmokeTests.swift \
+  -o /tmp/keyscribe-whisper-catalog-smoke-tests
+
+/tmp/keyscribe-whisper-catalog-smoke-tests
+
+swiftc \
+  Sources/KeyScribe/Services/ShortcutValidationRules.swift \
+  Sources/KeyScribe/Support/ShortcutValidation.swift \
+  Sources/KeyScribe/Services/MicrophoneManager.swift \
+  Sources/KeyScribe/Services/TextCleanup.swift \
+  Sources/KeyScribe/Services/SettingsStore.swift \
+  Scripts/SettingsStoreWhisperSmokeTests.swift \
+  -o /tmp/keyscribe-settings-whisper-smoke-tests
+
+/tmp/keyscribe-settings-whisper-smoke-tests

--- a/Scripts/update-whisper-framework.sh
+++ b/Scripts/update-whisper-framework.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="${1:-v1.8.1}"
+ZIP_NAME="whisper-${VERSION}-xcframework.zip"
+URL="https://github.com/ggml-org/whisper.cpp/releases/download/${VERSION}/${ZIP_NAME}"
+DEST_DIR="Vendor/Whisper"
+DEST_XCFRAMEWORK="${DEST_DIR}/whisper.xcframework"
+
+mkdir -p "$DEST_DIR"
+TMP_DIR="$(mktemp -d)"
+
+echo "Downloading ${URL}..."
+curl -fL "$URL" -o "$TMP_DIR/$ZIP_NAME"
+
+echo "Extracting framework..."
+unzip -q "$TMP_DIR/$ZIP_NAME" -d "$TMP_DIR/extracted"
+
+SRC_XCFRAMEWORK="$(find "$TMP_DIR/extracted" -type d -name whisper.xcframework | head -n 1)"
+if [ -z "$SRC_XCFRAMEWORK" ]; then
+    echo "Failed to find whisper.xcframework in downloaded archive"
+    exit 1
+fi
+
+if [ -d "$DEST_XCFRAMEWORK" ]; then
+    BACKUP_PATH="${DEST_XCFRAMEWORK}.backup.$(date +%s)"
+    mv "$DEST_XCFRAMEWORK" "$BACKUP_PATH"
+    echo "Existing framework moved to ${BACKUP_PATH}"
+fi
+
+cp -R "$SRC_XCFRAMEWORK" "$DEST_XCFRAMEWORK"
+
+CHECKSUM="$(swift package compute-checksum "$TMP_DIR/$ZIP_NAME")"
+
+echo ""
+echo "whisper framework updated at ${DEST_XCFRAMEWORK}"
+echo "Version: ${VERSION}"
+echo "Checksum: ${CHECKSUM}"
+echo ""
+echo "If using URL-based binary target, update checksum in Package.swift."

--- a/Sources/KeyScribe/App.swift
+++ b/Sources/KeyScribe/App.swift
@@ -1,5 +1,6 @@
 import AppKit
 import AVFoundation
+import Combine
 import Speech
 import SwiftUI
 
@@ -18,17 +19,16 @@ struct KeyScribeApp: App {
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    private enum PermissionPromptKeys {
-        static let autoRestartAfterAccessibilityGrant = "KeyScribe.autoRestartAfterAccessibilityGrant"
-    }
-
     private enum PasteLastTranscriptShortcut {
         static let keyCode: UInt16 = 9 // V
         static let modifiers: NSEvent.ModifierFlags = [.command, .option]
     }
 
     private let transcriber = SpeechTranscriber()
+    private let whisperModelManager = WhisperModelManager.shared
     private let settings = SettingsStore.shared
+    private let adaptiveCorrectionStore = AdaptiveCorrectionStore.shared
+    private let postInsertCorrectionMonitor = PostInsertCorrectionMonitor()
     private let waveform = WaveformHUDManager()
     private var hotkeyManager: HoldToTalkManager?
     private var continuousToggleHotkeyManager: OneShotHotkeyManager?
@@ -39,13 +39,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var statusLabelItem: NSMenuItem?
     private var startStopMenuItem: NSMenuItem?
-    private var accessibilityMenuItem: NSMenuItem?
+    private var permissionSetupMenuItem: NSMenuItem?
     private var accessibilityTrustObserver: NSObjectProtocol?
     private var workspaceActivationObserver: NSObjectProtocol?
-    private var isRelaunchingForAccessibility = false
-    private var awaitingAccessibilityGrant = false
-    private var accessibilityGrantMonitorTimer: DispatchSourceTimer?
-    private var accessibilityGrantMonitorDeadline: Date?
+    private var adaptiveCorrectionObserver: AnyCancellable?
+    private var permissionsReady = false
+    private var didRequestStartupPermissionPrompt = false
     private var lastExternalApplication: NSRunningApplication?
     private var lastTargetApplication: NSRunningApplication?
     private var currentAudioLevel: Float = 0
@@ -53,6 +52,91 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var dictationInputMode: DictationInputMode = .idle
     private var statusIconAnimationTimer: DispatchSourceTimer?
     private var statusIconAnimationPhase: Double = 0
+    private enum DictationFeedbackCue: CaseIterable {
+        case startListening
+        case stopListening
+        case processing
+        case pasted
+        case correctionLearned
+
+        var systemSoundName: String {
+            switch self {
+            case .startListening, .processing:
+                return SettingsStore.defaultDictationStartSoundName
+            case .stopListening:
+                return SettingsStore.defaultDictationStopSoundName
+            case .pasted:
+                return SettingsStore.defaultDictationPastedSoundName
+            case .correctionLearned:
+                return SettingsStore.defaultDictationCorrectionLearnedSoundName
+            }
+        }
+
+        @MainActor func resolvedSystemSoundName(settings: SettingsStore) -> String {
+            switch self {
+            case .startListening:
+                return Self.resolveSoundName(settings.dictationStartSoundName, fallback: Self.startingFallback)
+            case .stopListening:
+                return Self.resolveSoundName(settings.dictationStopSoundName, fallback: Self.stopFallback)
+            case .processing:
+                return Self.resolveSoundName(settings.dictationProcessingSoundName, fallback: Self.processingFallback)
+            case .pasted:
+                return Self.resolveSoundName(settings.dictationPastedSoundName, fallback: Self.pastedFallback)
+            case .correctionLearned:
+                return Self.resolveSoundName(settings.dictationCorrectionLearnedSoundName, fallback: Self.correctionLearnedFallback)
+            }
+        }
+
+        @MainActor static func resolveSoundName(_ selected: String, fallback: String) -> String {
+            if selected == SettingsStore.noDictationSoundName {
+                return ""
+            }
+            return SettingsStore.dictationStartSoundOptions.contains(selected)
+                ? selected
+                : fallback
+        }
+
+        private static var startingFallback: String {
+            SettingsStore.defaultDictationStartSoundName
+        }
+
+        private static var stopFallback: String {
+            SettingsStore.defaultDictationStopSoundName
+        }
+
+        private static var processingFallback: String {
+            SettingsStore.defaultDictationProcessingSoundName
+        }
+
+        private static var pastedFallback: String {
+            SettingsStore.defaultDictationPastedSoundName
+        }
+
+        private static var correctionLearnedFallback: String {
+            SettingsStore.defaultDictationCorrectionLearnedSoundName
+        }
+
+        var volumeMultiplier: Float {
+            switch self {
+            case .startListening:
+                return 0.7
+            default:
+                return 1
+            }
+        }
+    }
+
+    private var dictationFeedbackSounds: [DictationFeedbackCue: NSSound] {
+        var sounds: [DictationFeedbackCue: NSSound] = [:]
+        for cue in DictationFeedbackCue.allCases {
+            let soundName = cue.resolvedSystemSoundName(settings: settings)
+            guard !soundName.isEmpty else { continue }
+            if let sound = NSSound(named: NSSound.Name(soundName)) {
+                sounds[cue] = sound
+            }
+        }
+        return sounds
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         CrashReporter.install()
@@ -71,19 +155,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         settings.refreshMicrophones(notifyChange: false)
+        syncWhisperModelSelectionIfNeeded()
+        observeAdaptiveCorrectionChanges()
         transcriber.applyMicrophoneSettings(autoDetect: settings.autoDetectMicrophone, microphoneUID: settings.selectedMicrophoneUID)
-        transcriber.applyRecognitionSettings(
-            enableContextualBias: settings.enableContextualBias,
-            keepTextAcrossPauses: settings.keepTextAcrossPauses,
-            recognitionMode: settings.recognitionMode,
-            autoPunctuation: settings.autoPunctuation,
-            finalizeDelaySeconds: settings.finalizeDelaySeconds,
-            customContextPhrases: settings.customContextPhrases
+        applyRecognitionSettingsToTranscriber()
+        transcriber.applyWhisperSettings(
+            selectedModelID: settings.selectedWhisperModelID,
+            useCoreML: settings.whisperUseCoreML
         )
+        transcriber.setTranscriptionEngine(settings.transcriptionEngine)
+
+        postInsertCorrectionMonitor.onCorrectionDetected = { [weak self] result in
+            Task { @MainActor in
+                self?.handleLearnedCorrection(
+                    from: result.originalText,
+                    correctedText: result.correctedText,
+                    insertedText: result.insertedText
+                )
+            }
+        }
 
         transcriber.onStatusUpdate = { [weak self] message in
             Task { @MainActor in
-                self?.setUIStatus(DictationUIStatus.fromTranscriberMessage(message))
+                guard let self else { return }
+                let status = DictationUIStatus.fromTranscriberMessage(message)
+                self.showHUDAlertIfNeeded(forTranscriberMessage: message)
+                if status == .finalizing {
+                    self.playDictationFeedbackSound(.processing)
+                }
+                self.setUIStatus(status)
             }
         }
 
@@ -99,7 +199,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 self?.isDictating = isRecording
                 if !isRecording {
-                    if let currentMode = self?.dictationInputMode {
+        if let currentMode = self?.dictationInputMode {
                         self?.dictationInputMode = DictationInputModeStateMachine.onRecordingEnded(currentMode)
                     }
                     self?.stopStatusIconAnimation()
@@ -116,8 +216,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let cleaned = TextCleanup.process(text, mode: self.settings.textCleanupMode)
             guard !cleaned.isEmpty else { return }
 
-            self.transcriptHistory.add(cleaned)
-            self.insertText(cleaned)
+            let readyForInsert: String
+            var appliedEvents: [AdaptiveCorrectionStore.AppliedEvent] = []
+            if self.settings.adaptiveCorrectionsEnabled {
+                let applyResult = self.adaptiveCorrectionStore.applyWithEvents(to: cleaned)
+                readyForInsert = applyResult.text
+                appliedEvents = applyResult.appliedEvents
+            } else {
+                readyForInsert = cleaned
+            }
+
+            if !appliedEvents.isEmpty {
+                let applyMessage: String
+                if appliedEvents.count == 1, let first = appliedEvents.first {
+                    applyMessage = "Applied learned: \(first.source) -> \(first.replacement)"
+                } else {
+                    applyMessage = "Applied \(appliedEvents.count) learned corrections"
+                }
+                self.waveform.flashEvent(
+                    message: applyMessage,
+                    symbolName: "arrow.triangle.2.circlepath.circle.fill",
+                    duration: 1.2
+                )
+            }
+
+            self.transcriptHistory.add(readyForInsert)
+            self.insertText(readyForInsert, trackCorrections: self.settings.adaptiveCorrectionsEnabled)
             Task { @MainActor in
                 self.setUIStatus(.ready)
             }
@@ -156,20 +280,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                guard let self else { return }
-                if self.awaitingAccessibilityGrant {
-                    self.setUIStatus(.message("Accessibility updated. Verifying access…"))
-                    self.checkAccessibilityGrantProgress()
-                }
+                self?.updatePermissionGate(openOnboardingIfNeeded: true, reconfigureHotkeysIfReady: true)
             }
         }
 
-        // Safe to call every launch; system prompts only appear when status is undecided.
-        transcriber.requestPermissions(promptIfNeeded: true)
-        maybeAutoPromptAccessibilityOnce()
-        applyHotkeyMode()
-        configurePasteLastTranscriptHotkey()
-        updateMenuState()
+        updatePermissionGate(openOnboardingIfNeeded: true, reconfigureHotkeysIfReady: true)
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -181,15 +296,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
             self.workspaceActivationObserver = nil
         }
+        adaptiveCorrectionObserver?.cancel()
+        adaptiveCorrectionObserver = nil
         pasteLastTranscriptHotkeyManager?.stop()
         pasteLastTranscriptHotkeyManager = nil
         hotkeyManager?.stop()
         hotkeyManager = nil
         continuousToggleHotkeyManager?.stop()
         continuousToggleHotkeyManager = nil
-        stopAccessibilityGrantMonitor()
         stopStatusIconAnimation()
         transcriber.stopRecording()
+        postInsertCorrectionMonitor.stopMonitoring(commitSession: false)
         waveform.hide()
         windowCoordinator?.closeAllWindows()
         windowCoordinator = nil
@@ -197,183 +314,94 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         dictationInputMode = .idle
     }
 
-    private func requestAccessibilityIfNeeded(prompt: Bool) {
-        settings.refreshAccessibilityStatus(prompt: prompt)
-        if !settings.accessibilityTrusted {
-            setUIStatus(.accessibilityHint)
-        }
-    }
-
-    private func maybeAutoPromptAccessibilityOnce() {
-        settings.refreshAccessibilityStatus(prompt: false)
-        guard !settings.accessibilityTrusted else { return }
-        promptForAccessibilityAccessAtLaunch()
-    }
-
-    private var shouldAutoRestartAfterAccessibilityGrant: Bool {
-        let defaults = UserDefaults.standard
-        if defaults.object(forKey: PermissionPromptKeys.autoRestartAfterAccessibilityGrant) == nil {
-            defaults.set(true, forKey: PermissionPromptKeys.autoRestartAfterAccessibilityGrant)
-            return true
-        }
-        return defaults.bool(forKey: PermissionPromptKeys.autoRestartAfterAccessibilityGrant)
-    }
-
-    private func promptForAccessibilityAccessAtLaunch() {
-        guard !settings.accessibilityTrusted else { return }
-
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = "Accessibility Access Needed"
-        alert.informativeText = "KeyScribe needs Accessibility access to paste text into other apps. Grant access in System Settings."
-        alert.addButton(withTitle: "Grant Access")
-        alert.addButton(withTitle: "Not Now")
-
-        let autoRestartCheckbox = NSButton(
-            checkboxWithTitle: "Restart KeyScribe automatically after access is granted",
-            target: nil,
-            action: nil
-        )
-        autoRestartCheckbox.state = shouldAutoRestartAfterAccessibilityGrant ? .on : .off
-        alert.accessoryView = autoRestartCheckbox
-
-        let response = alert.runModal()
-        let autoRestartEnabled = autoRestartCheckbox.state == .on
-        UserDefaults.standard.set(autoRestartEnabled, forKey: PermissionPromptKeys.autoRestartAfterAccessibilityGrant)
-
-        if response == .alertFirstButtonReturn {
-            beginAccessibilityGrantFlow()
-        } else {
-            setUIStatus(.accessibilityHint)
-        }
-    }
-
-    private func beginAccessibilityGrantFlow() {
-        awaitingAccessibilityGrant = true
-        startAccessibilityGrantMonitor()
-        requestAccessibilityIfNeeded(prompt: true)
-
-        if settings.accessibilityTrusted {
-            completeAccessibilityGrantFlow()
-            return
-        }
-
-        setUIStatus(.message("Grant Accessibility in System Settings, then return to KeyScribe"))
-        openAccessibilitySettings()
-    }
-
     func applicationDidBecomeActive(_ notification: Notification) {
-        guard awaitingAccessibilityGrant else { return }
-        checkAccessibilityGrantProgress()
+        updatePermissionGate(openOnboardingIfNeeded: true)
     }
 
-    private func promptToRestartAfterAccessibilityGrant() {
-        let alert = NSAlert()
-        alert.alertStyle = .informational
-        alert.messageText = "Accessibility Granted"
-        alert.informativeText = "Restart KeyScribe now to apply Accessibility access for reliable paste and hotkeys."
-        alert.addButton(withTitle: "Restart Now")
-        alert.addButton(withTitle: "Later")
+    private func currentPermissionSnapshot() -> PermissionCenter.Snapshot {
+        PermissionCenter.snapshot(using: settings)
+    }
 
-        if alert.runModal() == .alertFirstButtonReturn {
-            relaunchAfterAccessibilityGrant()
+    private func updatePermissionGate(openOnboardingIfNeeded: Bool, reconfigureHotkeysIfReady: Bool = false) {
+        let snapshot = currentPermissionSnapshot()
+        let wasReady = permissionsReady
+        permissionsReady = snapshot.allRequiredGranted
+
+        if permissionsReady {
+            transcriber.requestPermissions(promptIfNeeded: false)
+            windowCoordinator?.closePermissionOnboardingWindow()
+            if !wasReady || reconfigureHotkeysIfReady {
+                applyHotkeyMode()
+                configurePasteLastTranscriptHotkey()
+            }
+            if !isDictating {
+                setUIStatus(.ready)
+            }
         } else {
-            setUIStatus(.message("Accessibility granted. Restart KeyScribe to apply it."))
-        }
-    }
-
-    private func relaunchAfterAccessibilityGrant() {
-        guard !isRelaunchingForAccessibility else { return }
-        isRelaunchingForAccessibility = true
-
-        let bundleURL = Bundle.main.bundleURL.standardizedFileURL
-        guard bundleURL.pathExtension.lowercased() == "app" else {
-            isRelaunchingForAccessibility = false
-            setUIStatus(.message("Accessibility granted. Please restart KeyScribe once."))
-            return
-        }
-
-        setUIStatus(.message("Accessibility granted — restarting KeyScribe…"))
-
-        let config = NSWorkspace.OpenConfiguration()
-        config.activates = true
-        config.createsNewApplicationInstance = true
-
-        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { [weak self] _, error in
-            Task { @MainActor in
-                guard let self else { return }
-                if error != nil {
-                    self.isRelaunchingForAccessibility = false
-                    self.setUIStatus(.message("Accessibility granted. Restart KeyScribe manually."))
-                    return
-                }
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                    NSApp.terminate(nil)
-                }
+            stopPermissionDependentFeatures()
+            setUIStatus(.message(permissionGateMessage(for: snapshot)))
+            if openOnboardingIfNeeded {
+                windowCoordinator?.openPermissionOnboardingWindow(onComplete: { [weak self] in
+                    Task { @MainActor in
+                        self?.updatePermissionGate(openOnboardingIfNeeded: true, reconfigureHotkeysIfReady: true)
+                    }
+                })
+                requestStartupPermissionPromptIfNeeded()
             }
         }
+
+        updateMenuState()
     }
 
-    private func openAccessibilitySettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else {
-            return
+    private func stopPermissionDependentFeatures() {
+        if isDictating {
+            transcriber.stopRecording(emitFinalText: false)
         }
-        NSWorkspace.shared.open(url)
+        hotkeyManager?.stop()
+        hotkeyManager = nil
+        continuousToggleHotkeyManager?.stop()
+        continuousToggleHotkeyManager = nil
+        pasteLastTranscriptHotkeyManager?.stop()
+        pasteLastTranscriptHotkeyManager = nil
+        isDictating = false
+        dictationInputMode = .idle
+        currentAudioLevel = 0
+        waveform.hide()
+        stopStatusIconAnimation()
     }
 
-    private func startAccessibilityGrantMonitor() {
-        stopAccessibilityGrantMonitor()
-        accessibilityGrantMonitorDeadline = Date().addingTimeInterval(120)
+    private func permissionGateMessage(for snapshot: PermissionCenter.Snapshot) -> String {
+        var missingPermissions: [String] = []
+        if !snapshot.accessibilityGranted {
+            missingPermissions.append("Accessibility")
+        }
+        if !snapshot.microphoneGranted {
+            missingPermissions.append("Microphone")
+        }
+        if snapshot.speechRecognitionRequired && !snapshot.speechRecognitionGranted {
+            missingPermissions.append("Speech Recognition")
+        }
 
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now() + 0.4, repeating: 0.6)
-        timer.setEventHandler { [weak self] in
+        guard !missingPermissions.isEmpty else {
+            return "Complete permission setup to start KeyScribe"
+        }
+
+        if missingPermissions.count == 1, let permission = missingPermissions.first {
+            return "Grant \(permission) permission to start KeyScribe"
+        }
+
+        let permissionList = missingPermissions.joined(separator: ", ")
+        return "Grant required permissions (\(permissionList)) to start KeyScribe"
+    }
+
+    private func requestStartupPermissionPromptIfNeeded() {
+        guard !didRequestStartupPermissionPrompt else { return }
+        didRequestStartupPermissionPrompt = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
             guard let self else { return }
-            self.checkAccessibilityGrantProgress()
-        }
-        accessibilityGrantMonitorTimer = timer
-        timer.resume()
-    }
-
-    private func stopAccessibilityGrantMonitor() {
-        accessibilityGrantMonitorTimer?.cancel()
-        accessibilityGrantMonitorTimer = nil
-        accessibilityGrantMonitorDeadline = nil
-    }
-
-    private func checkAccessibilityGrantProgress() {
-        guard awaitingAccessibilityGrant else {
-            stopAccessibilityGrantMonitor()
-            return
-        }
-
-        settings.refreshAccessibilityStatus(prompt: false)
-        if settings.accessibilityTrusted {
-            completeAccessibilityGrantFlow()
-            return
-        }
-
-        if let deadline = accessibilityGrantMonitorDeadline, Date() >= deadline {
-            stopAccessibilityGrantMonitor()
-            setUIStatus(.accessibilityHint)
-        }
-    }
-
-    private func completeAccessibilityGrantFlow() {
-        guard awaitingAccessibilityGrant else { return }
-        awaitingAccessibilityGrant = false
-        stopAccessibilityGrantMonitor()
-
-        if shouldAutoRestartAfterAccessibilityGrant {
-            relaunchAfterAccessibilityGrant()
-            return
-        }
-
-        if NSApp.isActive {
-            promptToRestartAfterAccessibilityGrant()
-        } else {
-            setUIStatus(.message("Accessibility granted. Open KeyScribe to restart and apply it."))
+            guard !self.permissionsReady else { return }
+            self.transcriber.requestPermissions(promptIfNeeded: true)
         }
     }
 
@@ -411,11 +439,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         settingsItem.target = self
         menu.addItem(settingsItem)
 
-        let accessibilityItem = NSMenuItem(title: "Grant Accessibility Access…", action: #selector(requestAccessibilityMenuItem(_:)), keyEquivalent: "")
-        accessibilityItem.target = self
-        accessibilityItem.isHidden = settings.accessibilityTrusted
-        menu.addItem(accessibilityItem)
-        self.accessibilityMenuItem = accessibilityItem
+        let permissionItem = NSMenuItem(title: "Complete Permission Setup…", action: #selector(requestAccessibilityMenuItem(_:)), keyEquivalent: "")
+        permissionItem.target = self
+        permissionItem.isHidden = permissionsReady
+        menu.addItem(permissionItem)
+        self.permissionSetupMenuItem = permissionItem
 
         if CrashReporter.hasLogs {
             let crashLogsItem = NSMenuItem(title: "View Crash Logs…", action: #selector(viewCrashLogs(_:)), keyEquivalent: "")
@@ -433,17 +461,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func applySettingsChanges() {
         settings.refreshMicrophones(notifyChange: false)
+        syncWhisperModelSelectionIfNeeded()
         transcriber.applyMicrophoneSettings(autoDetect: settings.autoDetectMicrophone, microphoneUID: settings.selectedMicrophoneUID)
+        applyRecognitionSettingsToTranscriber()
+        transcriber.applyWhisperSettings(
+            selectedModelID: settings.selectedWhisperModelID,
+            useCoreML: settings.whisperUseCoreML
+        )
+        transcriber.setTranscriptionEngine(settings.transcriptionEngine)
+        if !settings.adaptiveCorrectionsEnabled {
+            postInsertCorrectionMonitor.stopMonitoring(commitSession: false)
+        }
+        updatePermissionGate(openOnboardingIfNeeded: true, reconfigureHotkeysIfReady: true)
+    }
+
+    private func observeAdaptiveCorrectionChanges() {
+        adaptiveCorrectionObserver = adaptiveCorrectionStore.$learnedCorrections
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.applyRecognitionSettingsToTranscriber()
+            }
+    }
+
+    private func applyRecognitionSettingsToTranscriber() {
+        let adaptiveBiasPhrases: [String]
+        if settings.adaptiveCorrectionsEnabled {
+            adaptiveBiasPhrases = adaptiveCorrectionStore.preferredRecognitionPhrases()
+        } else {
+            adaptiveBiasPhrases = []
+        }
+
         transcriber.applyRecognitionSettings(
             enableContextualBias: settings.enableContextualBias,
             keepTextAcrossPauses: settings.keepTextAcrossPauses,
             recognitionMode: settings.recognitionMode,
             autoPunctuation: settings.autoPunctuation,
             finalizeDelaySeconds: settings.finalizeDelaySeconds,
-            customContextPhrases: settings.customContextPhrases
+            customContextPhrases: settings.customContextPhrases,
+            adaptiveBiasPhrases: adaptiveBiasPhrases
         )
-        applyHotkeyMode()
-        updateMenuState()
+    }
+
+    private func syncWhisperModelSelectionIfNeeded() {
+        guard settings.transcriptionEngine == .whisperCpp else { return }
+
+        whisperModelManager.refreshInstallStates()
+        if whisperModelManager.hasInstalledModel(id: settings.selectedWhisperModelID) {
+            return
+        }
+
+        if let fallbackModel = WhisperModelCatalog.curatedModels.first(where: { whisperModelManager.hasInstalledModel(id: $0.id) }) {
+            settings.selectedWhisperModelID = fallbackModel.id
+        } else {
+            settings.selectedWhisperModelID = ""
+        }
     }
 
     private func applyHotkeyMode() {
@@ -451,10 +522,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyManager = nil
         continuousToggleHotkeyManager?.stop()
         continuousToggleHotkeyManager = nil
+        guard permissionsReady else { return }
 
         hotkeyManager = HoldToTalkManager(
             keyCode: settings.shortcutKeyCode,
             modifiers: settings.shortcutModifierFlags,
+            suppressSystemShortcutSounds: settings.muteSystemSoundsWhileHoldingShortcut,
             onStart: { [weak self] in self?.startHoldToTalkDictation() },
             onStop: { [weak self] in self?.stopHoldToTalkDictation() }
         )
@@ -499,6 +572,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func configurePasteLastTranscriptHotkey() {
         pasteLastTranscriptHotkeyManager?.stop()
+        guard permissionsReady else {
+            pasteLastTranscriptHotkeyManager = nil
+            return
+        }
         pasteLastTranscriptHotkeyManager = OneShotHotkeyManager(
             keyCode: PasteLastTranscriptShortcut.keyCode,
             modifiers: PasteLastTranscriptShortcut.modifiers
@@ -521,7 +598,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func requestAccessibilityMenuItem(_ sender: Any?) {
-        beginAccessibilityGrantFlow()
+        updatePermissionGate(openOnboardingIfNeeded: true)
     }
 
     @objc private func pasteLastTranscriptMenuItem(_ sender: Any?) {
@@ -578,6 +655,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func startRecording() {
         guard !isDictating else { return }
+        guard permissionsReady else {
+            updatePermissionGate(openOnboardingIfNeeded: true)
+            return
+        }
+        postInsertCorrectionMonitor.stopMonitoring(commitSession: false)
 
         if let frontmost = NSWorkspace.shared.frontmostApplication,
            frontmost.processIdentifier != ProcessInfo.processInfo.processIdentifier {
@@ -592,14 +674,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         isDictating = started
 
         if started {
+            playDictationFeedbackSound(.startListening)
             setUIStatus(.listening)
             waveform.show()
             startStatusIconAnimation()
         } else {
             waveform.hide()
             stopStatusIconAnimation()
-            // If permissions are missing/undetermined, trigger the request path right away.
-            transcriber.requestPermissions(promptIfNeeded: true)
+            updatePermissionGate(openOnboardingIfNeeded: true)
+            if settings.transcriptionEngine == .whisperCpp,
+               !whisperModelManager.hasInstalledModel(id: settings.selectedWhisperModelID) {
+                setUIStatus(.message("Install a whisper model in Settings > Recognition to start dictation"))
+                windowCoordinator?.openSettingsWindow()
+            }
         }
 
         updateMenuState()
@@ -614,6 +701,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         setUIStatus(.finalizing)
+        playDictationFeedbackSound(.stopListening)
         transcriber.stopRecording()
         isDictating = false
         currentAudioLevel = 0
@@ -622,11 +710,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         updateMenuState()
     }
 
-    private func insertText(_ text: String, forceCopyToClipboard: Bool = false, overrideCopyToClipboard: Bool? = nil) {
+    private func insertText(
+        _ text: String,
+        forceCopyToClipboard: Bool = false,
+        overrideCopyToClipboard: Bool? = nil,
+        trackCorrections: Bool = false
+    ) {
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard ensureAccessibilityReadyForInsertion() else { return }
         let copyToClipboard = overrideCopyToClipboard ?? (settings.copyToClipboard || forceCopyToClipboard)
-        attemptInsertText(text, copyToClipboard: copyToClipboard, attemptsRemaining: 5)
+        attemptInsertText(
+            text,
+            copyToClipboard: copyToClipboard,
+            attemptsRemaining: 5
+        ) { [weak self] didInsert in
+            guard let self else { return }
+            if didInsert {
+                self.playDictationFeedbackSound(.pasted)
+            }
+            guard trackCorrections else { return }
+            if didInsert {
+                self.postInsertCorrectionMonitor.startMonitoring(insertedText: text)
+            }
+        }
     }
 
     private func pasteLastTranscriptFromHistory() {
@@ -656,13 +762,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func ensureAccessibilityReadyForInsertion() -> Bool {
         settings.refreshAccessibilityStatus(prompt: false)
         guard settings.accessibilityTrusted else {
-            setUIStatus(.message("Enable Accessibility via menu: Grant Accessibility Access…"))
+            setUIStatus(.message("Enable Accessibility via menu: Complete Permission Setup…"))
+            updatePermissionGate(openOnboardingIfNeeded: true)
             return false
         }
         return true
     }
 
-    private func attemptInsertText(_ text: String, copyToClipboard: Bool, attemptsRemaining: Int) {
+    private func attemptInsertText(
+        _ text: String,
+        copyToClipboard: Bool,
+        attemptsRemaining: Int,
+        completion: ((Bool) -> Void)? = nil
+    ) {
         guard attemptsRemaining > 0 else {
             if copyToClipboard {
                 ensureClipboardFallback(text)
@@ -671,6 +783,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 setUIStatus(.message("Paste unavailable — transcript is in KeyScribe History"))
             }
             lastTargetApplication = nil
+            completion?(false)
             return
         }
 
@@ -686,7 +799,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             _ = target.activate(options: [.activateIgnoringOtherApps])
             if attemptsRemaining > 1 {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.26) { [weak self] in
-                    self?.attemptInsertText(text, copyToClipboard: copyToClipboard, attemptsRemaining: attemptsRemaining - 1)
+                    self?.attemptInsertText(
+                        text,
+                        copyToClipboard: copyToClipboard,
+                        attemptsRemaining: attemptsRemaining - 1,
+                        completion: completion
+                    )
                 }
                 return
             }
@@ -705,10 +823,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch retryPlan {
         case let .retry(delay, nextRetriesRemaining):
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                self?.attemptInsertText(text, copyToClipboard: copyToClipboard, attemptsRemaining: nextRetriesRemaining + 1)
+                self?.attemptInsertText(
+                    text,
+                    copyToClipboard: copyToClipboard,
+                    attemptsRemaining: nextRetriesRemaining + 1,
+                    completion: completion
+                )
             }
 
         case let .complete(statusMessage):
+            let didInsert = result == .pasted
             if let statusMessage, statusMessage.hasPrefix("Paste unavailable") {
                 if copyToClipboard {
                     ensureClipboardFallback(text)
@@ -728,7 +852,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 applyInsertionStatusMessage(statusMessage)
             }
             lastTargetApplication = nil
+            completion?(didInsert)
         }
+    }
+
+    private func handleLearnedCorrection(from originalText: String, correctedText: String, insertedText: String) {
+        guard settings.adaptiveCorrectionsEnabled else { return }
+
+        let learningEvents = adaptiveCorrectionStore.learn(
+            from: originalText,
+            correctedText: correctedText,
+            insertionHint: insertedText
+        )
+        guard !learningEvents.isEmpty else { return }
+
+        let event = learningEvents[0]
+        let source = event.source
+        let replacement = event.replacement
+        let hudMessage = "Learned correction: \(source) -> \(replacement)"
+
+        waveform.flashEvent(
+            message: hudMessage,
+            symbolName: "arrow.triangle.2.circlepath.circle.fill",
+            duration: 1.2
+        )
+        if settings.playCorrectionLearnedSound {
+            playDictationFeedbackSound(.correctionLearned)
+        }
+        setUIStatus(.message(hudMessage))
     }
 
     private func ensureClipboardFallback(_ text: String) {
@@ -770,6 +921,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setUIStatus(.message(statusMessage))
     }
 
+    private func showHUDAlertIfNeeded(forTranscriberMessage message: String) {
+        if message.hasPrefix("Whisper finalize timed out and was reset") {
+            waveform.flashEvent(
+                message: "Whisper stalled and was reset. Retry now.",
+                symbolName: "exclamationmark.triangle.fill",
+                duration: 3.0
+            )
+            return
+        }
+
+        if message.hasPrefix("Whisper error:") {
+            waveform.flashEvent(
+                message: "Whisper failed. Check model and Core ML settings.",
+                symbolName: "xmark.octagon.fill",
+                duration: 2.4
+            )
+        }
+    }
+
     private func setUIStatus(_ status: DictationUIStatus) {
         statusLabelItem?.title = status.menuText
 
@@ -784,11 +954,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         updateMenuState()
     }
 
+    private func playDictationFeedbackSound(_ cue: DictationFeedbackCue) {
+        guard let sound = dictationFeedbackSounds[cue] else { return }
+        sound.stop()
+        sound.currentTime = 0
+        let baseVolume = min(1, max(0, Float(settings.dictationFeedbackVolume)))
+        sound.volume = baseVolume * cue.volumeMultiplier
+        sound.play()
+    }
+
     private func updateMenuState() {
         startStopMenuItem?.title = dictationInputMode == .continuous
             ? "Stop Continuous Dictation"
             : "Start Continuous Dictation"
-        accessibilityMenuItem?.isHidden = settings.accessibilityTrusted
+        startStopMenuItem?.isEnabled = permissionsReady
+        permissionSetupMenuItem?.isHidden = permissionsReady
         statusItem?.button?.image = makeStatusIcon(isRecording: isDictating, level: currentAudioLevel)
         statusItem?.button?.contentTintColor = nil
     }
@@ -825,12 +1005,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func makeStatusIcon(isRecording: Bool, level: Float) -> NSImage? {
         let normalizedLevel = max(0, min(1, level))
         let waveMotion = Float((sin(statusIconAnimationPhase) + 1) * 0.5)
-        let idlePulse = isRecording ? 0.10 + (0.07 * waveMotion) : 0
+        // Idle pulse sweeps from 0.3 to 0.7 so bars animate from center outward
+        let idlePulse = isRecording ? 0.30 + (0.40 * waveMotion) : 0
         let animatedLevel = isRecording ? max(normalizedLevel, idlePulse) : normalizedLevel
 
         let symbol: NSImage?
-        if #available(macOS 13.0, *) {
-            let variableValue = isRecording ? max(0.12, Double(animatedLevel)) : 0
+        if #available(macOS 13.3, *) {
+            let variableValue = isRecording ? max(0.30, Double(animatedLevel)) : 0
             symbol = NSImage(systemSymbolName: "waveform", variableValue: variableValue, accessibilityDescription: "KeyScribe")
         } else {
             symbol = NSImage(systemSymbolName: "waveform", accessibilityDescription: "KeyScribe")
@@ -840,20 +1021,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return nil
         }
 
-        let baseConfig = NSImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
         if isRecording {
-            let paletteConfig = NSImage.SymbolConfiguration(paletteColors: [
-                NSColor.white,
-                NSColor(calibratedWhite: 0.85, alpha: 1.0),
-                NSColor(calibratedWhite: 0.70, alpha: 1.0)
-            ])
-            let combined = baseConfig.applying(paletteConfig)
-            let configured = symbol.withSymbolConfiguration(combined)
-            configured?.isTemplate = false
+            let recordingConfig = NSImage.SymbolConfiguration(pointSize: 14, weight: .heavy)
+            let configured = symbol.withSymbolConfiguration(recordingConfig)
+            configured?.isTemplate = true
             return configured
         }
 
-        let configured = symbol.withSymbolConfiguration(baseConfig)
+        let idleConfig = NSImage.SymbolConfiguration(pointSize: 14, weight: .heavy)
+        let configured = symbol.withSymbolConfiguration(idleConfig)
         configured?.isTemplate = true
         return configured
     }
@@ -865,6 +1041,8 @@ struct SettingsView: View {
         case shortcuts
         case microphone
         case recognition
+        case models
+        case corrections
         case about
 
         var id: Self { self }
@@ -875,6 +1053,8 @@ struct SettingsView: View {
             case .shortcuts: return "Shortcuts"
             case .microphone: return "Microphone"
             case .recognition: return "Recognition"
+            case .models: return "Models"
+            case .corrections: return "Corrections"
             case .about: return "About & Permissions"
             }
         }
@@ -884,7 +1064,9 @@ struct SettingsView: View {
             case .general: return "Output, clipboard, and appearance"
             case .shortcuts: return "Hold-to-talk and continuous toggle keys"
             case .microphone: return "Input device selection and refresh"
-            case .recognition: return "Accuracy, cleanup, and timing controls"
+            case .recognition: return "Speech behavior and text quality"
+            case .models: return "Install and select whisper models"
+            case .corrections: return "Learn from and manage text fixes"
             case .about: return "Permission health, diagnostics, and uninstall"
             }
         }
@@ -895,6 +1077,8 @@ struct SettingsView: View {
             case .shortcuts: return "keyboard"
             case .microphone: return "mic.fill"
             case .recognition: return "waveform"
+            case .models: return "shippingbox.fill"
+            case .corrections: return "text.badge.checkmark"
             case .about: return "info.circle"
             }
         }
@@ -905,6 +1089,8 @@ struct SettingsView: View {
             case .shortcuts: return .indigo
             case .microphone: return .red
             case .recognition: return .green
+            case .models: return .teal
+            case .corrections: return .mint
             case .about: return .orange
             }
         }
@@ -912,13 +1098,17 @@ struct SettingsView: View {
         var searchTerms: [String] {
             switch self {
             case .general:
-                return ["general", "clipboard", "waveform", "accessibility", "output"]
+                return ["general", "clipboard", "waveform", "accessibility", "output", "sound", "feedback"]
             case .shortcuts:
                 return ["shortcut", "keyboard", "hold to talk", "continuous", "hotkey"]
             case .microphone:
                 return ["microphone", "input", "device", "audio"]
             case .recognition:
-                return ["recognition", "punctuation", "context", "cleanup", "delay"]
+                return ["recognition", "engine", "punctuation", "context", "cleanup", "delay", "text quality", "speech"]
+            case .models:
+                return ["whisper", "model", "download", "install", "core ml", "tiny", "base", "small", "medium", "large"]
+            case .corrections:
+                return ["adaptive", "learned", "correction", "replacement", "sound", "edit", "remove", "clear"]
             case .about:
                 return ["about", "permission", "uninstall", "version", "crash logs"]
             }
@@ -933,6 +1123,21 @@ struct SettingsView: View {
     private struct ShortcutBinding: Equatable {
         let keyCode: UInt16
         let modifiersRaw: UInt
+    }
+
+    private struct ShortcutModifierOption: Identifiable {
+        let id: String
+        let label: String
+        let flag: NSEvent.ModifierFlags
+    }
+
+    private struct ShortcutKeyOption: Identifiable {
+        let keyCode: UInt16
+        let label: String
+
+        var id: UInt16 {
+            keyCode
+        }
     }
 
     private struct SettingSearchEntry: Identifiable {
@@ -951,13 +1156,41 @@ struct SettingsView: View {
         static let pasteLastModifiersRaw: UInt = NSEvent.ModifierFlags([.command, .option]).rawValue
     }
 
+    private static let manualModifierOnlyKeyCode: UInt16 = UInt16.max
+    private static let shortcutModifierOptions: [ShortcutModifierOption] = [
+        .init(id: "fn", label: "Fn", flag: .function),
+        .init(id: "control", label: "⌃", flag: .control),
+        .init(id: "option", label: "⌥", flag: .option),
+        .init(id: "shift", label: "⇧", flag: .shift),
+        .init(id: "command", label: "⌘", flag: .command)
+    ]
+
     @EnvironmentObject private var settings: SettingsStore
+    @StateObject private var whisperModelManager = WhisperModelManager.shared
+    @StateObject private var adaptiveCorrectionStore = AdaptiveCorrectionStore.shared
     @State private var selectedSection: SettingsSection = .general
     @State private var searchQuery = ""
     @State private var isCapturingShortcut = false
     @State private var shortcutCaptureTarget: ShortcutCaptureTarget?
     @State private var shortcutCaptureMessage: String?
+    @State private var showHoldManualMap = false
+    @State private var showContinuousManualMap = false
+    @State private var whisperModelSearchQuery = ""
+    @State private var whisperFamilyFilter = "all"
+    @State private var whisperShowInstalledOnly = false
+    @State private var whisperBrowserModelID = ""
     @State private var showUninstallConfirmation = false
+    @State private var uninstallDeleteDownloadedModels = false
+    @State private var uninstallDeleteLearnedCorrections = false
+    @State private var isCorrectionEditorPresented = false
+    @State private var correctionSourceDraft = ""
+    @State private var correctionReplacementDraft = ""
+    @State private var correctionEditingSource: String?
+    @State private var correctionDialogMessage: String?
+    private let settingsSidebarWidth: CGFloat = 278
+    private let manualShortcutKeyOptions: [ShortcutKeyOption] = ShortcutValidation.manualAssignableKeyCodes.map {
+        ShortcutKeyOption(keyCode: $0, label: ShortcutValidation.keyName(for: $0))
+    }
 
     var body: some View {
         ZStack {
@@ -971,49 +1204,27 @@ struct SettingsView: View {
             )
             .ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                settingsHeader
+            HStack(spacing: 0) {
+                settingsSidebar
                 Divider()
-                HStack(spacing: 0) {
-                    settingsSidebar
-                    Divider()
-                    settingsDetailPane
-                }
+                settingsDetailPane
             }
             .background(Color(nsColor: .windowBackgroundColor).opacity(0.65))
 
             ShortcutCaptureMonitor(
                 isCapturing: $isCapturingShortcut,
                 onCapture: { keyCode, modifiers in
-                    let filteredModifiers = ShortcutValidation.filteredModifierRawValue(from: modifiers)
-                    guard ShortcutValidation.isValid(keyCode: keyCode, modifiersRaw: filteredModifiers) else {
-                        shortcutCaptureMessage = "Shortcut must use 2 or 3 keys. Try again."
-                        return
-                    }
-
                     guard let target = shortcutCaptureTarget else {
                         return
                     }
 
-                    if let conflictMessage = shortcutConflictMessage(
+                    let didApply = applyShortcutSelection(
                         for: target,
                         keyCode: keyCode,
-                        modifiersRaw: filteredModifiers
-                    ) {
-                        shortcutCaptureMessage = conflictMessage
-                        return
-                    }
-
-                    switch target {
-                    case .holdToTalk:
-                        settings.shortcutKeyCode = keyCode
-                        settings.shortcutModifiers = filteredModifiers
-                    case .continuousToggle:
-                        settings.continuousToggleShortcutKeyCode = keyCode
-                        settings.continuousToggleShortcutModifiers = filteredModifiers
-                    }
-
-                    shortcutCaptureMessage = nil
+                        modifiersRaw: modifiers,
+                        validationMessage: "Shortcut must use 2 to 4 keys. Try again."
+                    )
+                    guard didApply else { return }
                     shortcutCaptureTarget = nil
                     isCapturingShortcut = false
                 },
@@ -1034,6 +1245,9 @@ struct SettingsView: View {
             } else if let firstSection = filteredSections.first {
                 selectedSection = firstSection
             }
+        }
+        .sheet(isPresented: $isCorrectionEditorPresented) {
+            correctionEditorSheet
         }
     }
 
@@ -1063,11 +1277,17 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var settingsSidebar: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            TextField("Search settings…", text: $searchQuery)
-                .textFieldStyle(.roundedBorder)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.callout)
+                    .foregroundStyle(.tertiary)
+                TextField("Search settings…", text: $searchQuery)
+                    .textFieldStyle(.roundedBorder)
+            }
+            .padding(.bottom, 4)
 
-            VStack(spacing: 6) {
+            VStack(spacing: 2) {
                 ForEach(filteredSections) { section in
                     Button {
                         selectedSection = section
@@ -1086,8 +1306,10 @@ struct SettingsView: View {
 
             Spacer(minLength: 0)
         }
-        .padding(16)
-        .frame(width: 260, alignment: .topLeading)
+        .padding(14)
+        .frame(width: settingsSidebarWidth, alignment: .topLeading)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
     }
 
     @ViewBuilder
@@ -1097,12 +1319,17 @@ struct SettingsView: View {
 
         HStack(spacing: 10) {
             Image(systemName: section.iconName)
-                .foregroundStyle(isSelected ? section.tint : .secondary)
-                .frame(width: 16)
+                .foregroundStyle(isSelected ? .white : section.tint)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 24, height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(isSelected ? section.tint : section.tint.opacity(0.12))
+                )
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(section.title)
-                    .font(.callout.weight(.semibold))
+                    .font(.callout.weight(isSelected ? .semibold : .medium))
                     .foregroundStyle(.primary)
                 Text(section.subtitle)
                     .font(.caption2)
@@ -1114,25 +1341,15 @@ struct SettingsView: View {
 
             if !trimmedSearchQuery.isEmpty && matchCount > 0 {
                 Text("\(matchCount)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(section.tint)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(
-                        Capsule()
-                            .fill(section.tint.opacity(0.14))
-                    )
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(isSelected ? section.tint.opacity(0.16) : Color.clear)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(isSelected ? section.tint.opacity(0.40) : Color.primary.opacity(0.08), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(isSelected ? Color.primary.opacity(0.08) : Color.clear)
         )
     }
 
@@ -1143,25 +1360,19 @@ struct SettingsView: View {
                 if !trimmedSearchQuery.isEmpty {
                     searchHighlightsCard
                 }
-
-                HStack(spacing: 10) {
-                    Image(systemName: selectedSection.iconName)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(selectedSection.tint)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(selectedSection.title)
-                            .font(.title3.weight(.semibold))
-                        Text(selectedSection.subtitle)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                }
-
                 sectionContent(for: selectedSection)
             }
             .padding(20)
             .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    @ViewBuilder
+    private func settingsSectionHeader(for section: SettingsSection) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(section.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -1218,6 +1429,10 @@ struct SettingsView: View {
             microphoneSection
         case .recognition:
             recognitionSection
+        case .models:
+            modelsSection
+        case .corrections:
+            correctionsSection
         case .about:
             aboutSection
         }
@@ -1226,12 +1441,54 @@ struct SettingsView: View {
     @ViewBuilder
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 14) {
+            settingsSectionHeader(for: .general)
             accessibilityCard
 
             settingsCard(title: "Dictation Output") {
                 Toggle("Also copy transcript to system clipboard", isOn: $settings.copyToClipboard)
                     .help("Turn off to keep dictations out of clipboard history. Explicit Copy actions from History still copy as expected.")
             }
+
+                    settingsCard(
+                        title: "Dictation Sounds",
+                        subtitle: "Choose the sounds for each dictation event."
+                    ) {
+                        VStack(alignment: .leading, spacing: 10) {
+                    dictationSoundRow(
+                        title: "Start listening",
+                        selection: $settings.dictationStartSoundName
+                    )
+
+                    dictationSoundRow(
+                        title: "Stop/Finalize",
+                        selection: $settings.dictationStopSoundName
+                    )
+
+                    dictationSoundRow(
+                        title: "Processing (finalize)",
+                        selection: $settings.dictationProcessingSoundName
+                    )
+
+                            dictationSoundRow(
+                                title: "Pasted",
+                                selection: $settings.dictationPastedSoundName
+                            )
+
+                            VStack(spacing: 6) {
+                                HStack {
+                                    Text("Feedback volume")
+                                        .font(.callout.weight(.medium))
+                                    Spacer()
+                                    Text("\(Int(settings.dictationFeedbackVolume * 100))%")
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 52, alignment: .trailing)
+                                }
+                                Slider(value: $settings.dictationFeedbackVolume, in: 0...1, step: 0.01)
+                                    .help("Reduce this value to lower all dictation feedback sounds.")
+                            }
+                        }
+                    }
 
             settingsCard(title: "Waveform Appearance") {
                 Picker("Waveform Theme", selection: $settings.waveformThemeRawValue) {
@@ -1256,8 +1513,28 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
+    private func dictationSoundRow(title: String, selection: Binding<String>) -> some View {
+        HStack {
+            Text(title)
+                .font(.callout.weight(.medium))
+            Spacer()
+            Picker("", selection: selection) {
+                ForEach(SettingsStore.dictationStartSoundOptions, id: \.self) { sound in
+                    Text(sound).tag(sound)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 200)
+        }
+        .help(selection.wrappedValue == SettingsStore.noDictationSoundName
+            ? "No sound for this event."
+            : "Play this sound when: \(title.lowercased())")
+    }
+
+    @ViewBuilder
     private var shortcutsSection: some View {
         VStack(alignment: .leading, spacing: 14) {
+            settingsSectionHeader(for: .shortcuts)
             settingsCard(
                 title: "Hold-to-Talk Shortcut",
                 subtitle: "Hold this shortcut while speaking."
@@ -1272,9 +1549,17 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.borderedProminent)
 
-                    Text("Use 2 or 3 keys, like ⌘+Space or ⌃+⌥+K.")
+                    Text("Use 2 to 4 keys, like ⌘+Space or ⌃+⌥+⌘+Space.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+
+                Toggle("Mute system sounds while this shortcut is held", isOn: $settings.muteSystemSoundsWhileHoldingShortcut)
+                    .help("Suppresses this hold-to-talk key chord in other apps to avoid system alert beeps.")
+
+                DisclosureGroup("Manual map (advanced)", isExpanded: $showHoldManualMap) {
+                    manualShortcutBuilder(for: .holdToTalk)
+                        .padding(.top, 6)
                 }
 
                 if isCapturingShortcut && shortcutCaptureTarget == .holdToTalk {
@@ -1284,7 +1569,7 @@ struct SettingsView: View {
                 }
 
                 if !isHoldToTalkShortcutValid {
-                    Text("Hold-to-talk shortcut must include exactly 2 or 3 keys.")
+                    Text("Hold-to-talk shortcut must include 2 to 4 keys.")
                         .font(.callout)
                         .foregroundStyle(.orange)
                 }
@@ -1304,9 +1589,14 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.borderedProminent)
 
-                    Text("Use 2 or 3 keys. Keep this different from hold-to-talk.")
+                    Text("Use 2 to 4 keys. Keep this different from hold-to-talk.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+
+                DisclosureGroup("Manual map (advanced)", isExpanded: $showContinuousManualMap) {
+                    manualShortcutBuilder(for: .continuousToggle)
+                        .padding(.top, 6)
                 }
 
                 if isCapturingShortcut && shortcutCaptureTarget == .continuousToggle {
@@ -1316,7 +1606,7 @@ struct SettingsView: View {
                 }
 
                 if !isContinuousToggleShortcutValid {
-                    Text("Continuous toggle shortcut must include 2 or 3 keys.")
+                    Text("Continuous toggle shortcut must include 2 to 4 keys.")
                         .font(.callout)
                         .foregroundStyle(.orange)
                 }
@@ -1338,27 +1628,30 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var microphoneSection: some View {
-        settingsCard(title: "Input Device") {
-            Toggle("Auto-detect microphone", isOn: $settings.autoDetectMicrophone)
+        VStack(alignment: .leading, spacing: 14) {
+            settingsSectionHeader(for: .microphone)
+            settingsCard(title: "Input Device") {
+                Toggle("Auto-detect microphone", isOn: $settings.autoDetectMicrophone)
 
-            HStack {
-                Picker("Microphone", selection: $settings.selectedMicrophoneUID) {
-                    ForEach(settings.availableMicrophones) { mic in
-                        Text(mic.name).tag(mic.uid)
+                HStack {
+                    Picker("Microphone", selection: $settings.selectedMicrophoneUID) {
+                        ForEach(settings.availableMicrophones) { mic in
+                            Text(mic.name).tag(mic.uid)
+                        }
                     }
-                }
-                .disabled(settings.autoDetectMicrophone)
+                    .disabled(settings.autoDetectMicrophone)
 
-                Button("Refresh") {
-                    settings.refreshMicrophones()
+                    Button("Refresh") {
+                        settings.refreshMicrophones()
+                    }
+                    .disabled(settings.autoDetectMicrophone)
                 }
-                .disabled(settings.autoDetectMicrophone)
-            }
 
-            if settings.availableMicrophones.isEmpty {
-                Text("No microphones detected.")
-                    .font(.callout)
-                    .foregroundStyle(.orange)
+                if settings.availableMicrophones.isEmpty {
+                    Text("No microphones detected.")
+                        .font(.callout)
+                        .foregroundStyle(.orange)
+                }
             }
         }
     }
@@ -1366,75 +1659,579 @@ struct SettingsView: View {
     @ViewBuilder
     private var recognitionSection: some View {
         VStack(alignment: .leading, spacing: 14) {
-            settingsCard(title: "Recognition Behavior") {
-                Toggle("Use contextual language bias", isOn: $settings.enableContextualBias)
-                    .help("Boost likely words/phrases for better recognition.")
-
-                Toggle("Preserve words across short pauses", isOn: $settings.keepTextAcrossPauses)
-                    .help("Helps avoid dropping earlier words when you pause briefly mid-sentence.")
-
+            settingsSectionHeader(for: .recognition)
+            settingsCard(title: "Transcription Engine") {
                 HStack {
-                    Text("Recognition mode")
+                    Text("Engine")
                         .font(.callout.weight(.medium))
                     Spacer()
-                    Picker("", selection: $settings.recognitionModeRawValue) {
-                        ForEach(RecognitionMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode.rawValue)
+                    Picker("", selection: $settings.transcriptionEngineRawValue) {
+                        ForEach(TranscriptionEngineType.allCases) { engine in
+                            Text(engine.displayName).tag(engine.rawValue)
                         }
                     }
                     .pickerStyle(.menu)
-                    .frame(width: 150)
+                    .frame(width: 200)
                 }
-                .help(settings.recognitionMode.helpText)
 
-                Text(settings.recognitionMode.helpText)
+                Text(settings.transcriptionEngine.helpText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-
-                Toggle("Enable Apple automatic punctuation", isOn: $settings.autoPunctuation)
-                    .help("Uses Apple Speech punctuation generation during recognition.")
             }
 
-            settingsCard(title: "Finalize Delay") {
-                Text("Finalize delay: \(Int(settings.finalizeDelaySeconds * 1000)) ms")
-                    .font(.callout.weight(.medium))
-                Slider(value: $settings.finalizeDelaySeconds, in: 0.15...1.2, step: 0.05)
-                Text("Lower = faster paste, higher = fewer cut-offs.")
+            if settings.transcriptionEngine == .appleSpeech {
+                settingsCard(
+                    title: "Apple Speech Behavior",
+                    subtitle: "Tune recognition behavior and punctuation for Apple Speech."
+                ) {
+                    Toggle("Use contextual language bias", isOn: $settings.enableContextualBias)
+                        .help("Boost likely words/phrases for better recognition.")
+
+                    Toggle("Preserve words across short pauses", isOn: $settings.keepTextAcrossPauses)
+                        .help("Helps avoid dropping earlier words when you pause briefly mid-sentence.")
+
+                    HStack {
+                        Text("Recognition mode")
+                            .font(.callout.weight(.medium))
+                        Spacer()
+                        Picker("", selection: $settings.recognitionModeRawValue) {
+                            ForEach(RecognitionMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 150)
+                    }
+                    .help(settings.recognitionMode.helpText)
+
+                    Text(settings.recognitionMode.helpText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Toggle("Enable Apple automatic punctuation", isOn: $settings.autoPunctuation)
+                        .help("Uses Apple Speech punctuation generation during recognition.")
+                }
+            } else {
+                settingsCard(
+                    title: "whisper.cpp",
+                    subtitle: "Model install and selection are managed in the Models section."
+                ) {
+                    Text("Open Models to install, delete, and switch whisper models.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        Button("Open Models") {
+                            selectedSection = .models
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Spacer()
+                    }
+                }
+            }
+
+            settingsCard(
+                title: "Text Quality & Timing",
+                subtitle: "Control finalize speed, cleanup, and custom vocabulary."
+            ) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Finalize delay: \(Int(settings.finalizeDelaySeconds * 1000)) ms")
+                        .font(.callout.weight(.medium))
+                    Slider(value: $settings.finalizeDelaySeconds, in: 0.15...1.2, step: 0.05)
+                    Text("Lower = faster paste, higher = fewer cut-offs.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Divider()
+
+                    HStack {
+                        Text("Cleanup mode")
+                            .font(.callout.weight(.medium))
+                        Spacer()
+                        Picker("", selection: $settings.textCleanupModeRawValue) {
+                            ForEach(TextCleanupMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 170)
+                    }
+                    .help("Light keeps original phrasing; Aggressive normalizes punctuation/casing more strongly.")
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Custom phrases (comma or new line separated)")
+                            .font(.callout.weight(.medium))
+                        TextEditor(text: $settings.customContextPhrases)
+                            .frame(height: 120)
+                            .font(.callout)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                            )
+                        Text("Examples: names, products, acronyms, slang")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            settingsCard(
+                title: "Adaptive Corrections",
+                subtitle: "Learning controls and correction management moved to a dedicated section."
+            ) {
+                Text("Open Corrections to review learned fixes, add custom replacements, and tune correction sound.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Button("Open Corrections") {
+                        selectedSection = .corrections
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var modelsSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            settingsSectionHeader(for: .models)
+
+            if settings.transcriptionEngine != .whisperCpp {
+                settingsCard(
+                    title: "whisper.cpp Required",
+                    subtitle: "Model install and selection are only used with whisper.cpp."
+                ) {
+                    Text("Switch the transcription engine to whisper.cpp to manage local models.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    Button("Switch to whisper.cpp") {
+                        settings.transcriptionEngine = .whisperCpp
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            } else {
+                settingsCard(title: "Model Runtime") {
+                    Toggle("Use Core ML encoder when available", isOn: $settings.whisperUseCoreML)
+                        .help("If installed for the selected model, Core ML can improve whisper speed on Apple Silicon.")
+
+                    if settings.selectedWhisperModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text("No model selected yet.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Current model: \(settings.selectedWhisperModelID)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                settingsCard(
+                    title: "Model Library",
+                    subtitle: "Browse, filter, install, and choose whisper models."
+                ) {
+                    if WhisperModelCatalog.curatedModels.isEmpty {
+                        Text("No curated whisper models are configured.")
+                            .font(.callout)
+                            .foregroundStyle(.orange)
+                    } else {
+                        VStack(alignment: .leading, spacing: 10) {
+                            HStack(spacing: 10) {
+                                TextField("Search model ID (e.g. medium, large-v3, q5)", text: $whisperModelSearchQuery)
+                                    .textFieldStyle(.roundedBorder)
+
+                                Toggle("Installed only", isOn: $whisperShowInstalledOnly)
+                                    .toggleStyle(.switch)
+                                    .fixedSize()
+                            }
+
+                            HStack(spacing: 10) {
+                                Picker("Family", selection: $whisperFamilyFilter) {
+                                    ForEach(whisperFamilyFilterOptions, id: \.self) { family in
+                                        Text(family == "all" ? "All families" : family.capitalized)
+                                            .tag(family)
+                                    }
+                                }
+                                .pickerStyle(.menu)
+                                .frame(width: 180)
+
+                                Spacer()
+
+                                Picker("Model", selection: $whisperBrowserModelID) {
+                                    ForEach(filteredWhisperModels) { model in
+                                        Text(model.displayName).tag(model.id)
+                                    }
+                                }
+                                .pickerStyle(.menu)
+                                .frame(width: 290)
+                            }
+
+                            if let browsingModel = activeWhisperBrowserModel {
+                                whisperModelRow(for: browsingModel)
+                            } else {
+                                Text("No models match the current filters.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.vertical, 6)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            refreshWhisperModelBrowserState()
+        }
+        .onChange(of: settings.transcriptionEngineRawValue) { _ in
+            if settings.transcriptionEngine == .whisperCpp {
+                refreshWhisperModelBrowserState()
+            }
+        }
+        .onChange(of: whisperModelSearchQuery) { _ in
+            ensureWhisperBrowserModelSelectionIsValid()
+        }
+        .onChange(of: whisperFamilyFilter) { _ in
+            ensureWhisperBrowserModelSelectionIsValid()
+        }
+        .onChange(of: whisperShowInstalledOnly) { _ in
+            ensureWhisperBrowserModelSelectionIsValid()
+        }
+        .onChange(of: whisperModelManager.installStateByModelID) { _ in
+            ensureSelectedWhisperModelIsValid()
+            ensureWhisperBrowserModelSelectionIsValid()
+        }
+        .onChange(of: settings.selectedWhisperModelID) { newValue in
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            if filteredWhisperModels.contains(where: { $0.id == trimmed }) {
+                whisperBrowserModelID = trimmed
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var correctionsSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            settingsSectionHeader(for: .corrections)
+
+            settingsCard(
+                title: "Adaptive Corrections",
+                subtitle: "Learn from quick edits and manage learned replacements."
+            ) {
+                Text("Learned corrections are used as recognition hints for Apple Speech and whisper.cpp.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Learn from quick post-insert corrections", isOn: $settings.adaptiveCorrectionsEnabled)
+
+                Toggle("Play sound when a correction is learned", isOn: $settings.playCorrectionLearnedSound)
+                    .disabled(!settings.adaptiveCorrectionsEnabled)
+
+                if settings.playCorrectionLearnedSound {
+                    dictationSoundRow(
+                        title: "Learned correction sound",
+                        selection: $settings.dictationCorrectionLearnedSoundName
+                    )
+                        .disabled(!settings.adaptiveCorrectionsEnabled)
+                } else {
+                    Text("Enable this option to play a custom sound when a correction is learned.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack {
+                    Button("Add Custom Correction…") {
+                        openCreateCorrectionDialog()
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Spacer()
+                }
+
+                if adaptiveCorrectionStore.learnedCorrections.isEmpty {
+                    Text("No learned corrections yet. Fix a mistaken word once and KeyScribe can learn it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(Array(adaptiveCorrectionStore.learnedCorrections.prefix(12)), id: \.id) { correction in
+                            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                Text(correction.source)
+                                    .font(.callout.monospaced())
+                                Image(systemName: "arrow.right")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                                Text(correction.replacement)
+                                    .font(.callout.monospaced())
+                                Spacer()
+                                Button("Edit") {
+                                    beginEditingCorrection(correction)
+                                }
+                                .buttonStyle(.borderless)
+                                Button("Remove") {
+                                    adaptiveCorrectionStore.removeCorrection(source: correction.source)
+                                }
+                                .buttonStyle(.borderless)
+                            }
+                        }
+
+                        if adaptiveCorrectionStore.learnedCorrections.count > 12 {
+                            Text("Showing first 12 corrections.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        HStack {
+                            Spacer()
+                            Button("Clear Learned Corrections", role: .destructive) {
+                                adaptiveCorrectionStore.clearAll()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func refreshWhisperModelBrowserState() {
+        whisperModelManager.refreshInstallStates()
+        ensureSelectedWhisperModelIsValid()
+        ensureWhisperBrowserModelSelectionIsValid()
+    }
+
+    @ViewBuilder
+    private func whisperModelRow(for model: WhisperModelCatalog.Model) -> some View {
+        let installState = whisperModelManager.installStateByModelID[model.id] ?? .notInstalled
+        let isSelected = settings.selectedWhisperModelID == model.id
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(model.displayName)
+                    .font(.callout.weight(.semibold))
+
+                if model.isEnglishOnly {
+                    whisperModelBadge("EN")
+                }
+                if model.isQuantized {
+                    whisperModelBadge("Quantized")
+                }
+                if model.isDiarization {
+                    whisperModelBadge("Diarize")
+                }
+
+                if isSelected {
+                    Text("Selected")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.green)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.green.opacity(0.14)))
+                }
+                Spacer()
+                Text(model.diskSizeText)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Text(model.memoryFootprintText)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(model.useCaseDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            switch installState {
+            case .downloading(let progress):
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                Text("Downloading… \(Int(progress * 100))%")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+            case .installing:
+                Text("Installing model…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+            case .failed(let message):
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+
+            case .installed:
+                Text("Installed")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+
+            case .notInstalled:
+                Text("Not installed")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
-            settingsCard(title: "Cleanup & Vocabulary") {
-                HStack {
-                    Text("Cleanup mode")
-                        .font(.callout.weight(.medium))
-                    Spacer()
-                    Picker("", selection: $settings.textCleanupModeRawValue) {
-                        ForEach(TextCleanupMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode.rawValue)
+            HStack(spacing: 8) {
+                Button(isSelected ? "Using" : "Use Model") {
+                    settings.selectedWhisperModelID = model.id
+                }
+                .buttonStyle(.bordered)
+                .disabled(installState != .installed || isSelected)
+
+                switch installState {
+                case .downloading:
+                    Button("Cancel") {
+                        whisperModelManager.cancelDownload(modelID: model.id)
+                    }
+                    .buttonStyle(.bordered)
+
+                case .installing:
+                    Button("Installing…") {}
+                        .buttonStyle(.bordered)
+                        .disabled(true)
+
+                case .installed:
+                    Button("Delete") {
+                        whisperModelManager.deleteModel(modelID: model.id)
+                        if settings.selectedWhisperModelID == model.id {
+                            settings.selectedWhisperModelID = ""
                         }
                     }
-                    .pickerStyle(.menu)
-                    .frame(width: 170)
-                }
-                .help("Light keeps original phrasing; Aggressive normalizes punctuation/casing more strongly.")
+                    .buttonStyle(.bordered)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Custom phrases (comma or new line separated)")
-                        .font(.callout.weight(.medium))
-                    TextEditor(text: $settings.customContextPhrases)
-                        .frame(height: 120)
-                        .font(.callout)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                case .notInstalled, .failed:
+                    Button(installState.installButtonTitle) {
+                        whisperModelManager.installModel(
+                            modelID: model.id,
+                            includeCoreML: settings.whisperUseCoreML
                         )
-                    Text("Examples: names, products, acronyms, slang")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.borderedProminent)
                 }
             }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func whisperModelBadge(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(Color.primary.opacity(0.10))
+            )
+    }
+
+    private var whisperFamilyFilterOptions: [String] {
+        let defaultOrder = ["tiny", "base", "small", "medium", "large"]
+        let availableFamilies = Set(WhisperModelCatalog.curatedModels.map(\.family))
+
+        var options: [String] = ["all"]
+        for family in defaultOrder where availableFamilies.contains(family) {
+            options.append(family)
+        }
+        for family in availableFamilies.sorted() where !defaultOrder.contains(family) {
+            options.append(family)
+        }
+        return options
+    }
+
+    private var filteredWhisperModels: [WhisperModelCatalog.Model] {
+        var models = WhisperModelCatalog.curatedModels
+
+        if whisperFamilyFilter != "all" {
+            models = models.filter { $0.family == whisperFamilyFilter }
+        }
+
+        if whisperShowInstalledOnly {
+            models = models.filter { whisperModelManager.hasInstalledModel(id: $0.id) }
+        }
+
+        let query = whisperModelSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if !query.isEmpty {
+            models = models.filter { model in
+                model.id.lowercased().contains(query) ||
+                    model.useCaseDescription.lowercased().contains(query)
+            }
+        }
+
+        return models.sorted { lhs, rhs in
+            let rankByFamily: [String: Int] = [
+                "tiny": 0,
+                "base": 1,
+                "small": 2,
+                "medium": 3,
+                "large": 4
+            ]
+            let lhsRank = rankByFamily[lhs.family] ?? 99
+            let rhsRank = rankByFamily[rhs.family] ?? 99
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
+            return lhs.id < rhs.id
+        }
+    }
+
+    private var activeWhisperBrowserModel: WhisperModelCatalog.Model? {
+        guard !whisperBrowserModelID.isEmpty else { return nil }
+        guard filteredWhisperModels.contains(where: { $0.id == whisperBrowserModelID }) else {
+            return nil
+        }
+        return WhisperModelCatalog.model(withID: whisperBrowserModelID)
+    }
+
+    private func ensureWhisperBrowserModelSelectionIsValid() {
+        guard settings.transcriptionEngine == .whisperCpp else { return }
+
+        if filteredWhisperModels.isEmpty {
+            whisperBrowserModelID = ""
+            return
+        }
+
+        if filteredWhisperModels.contains(where: { $0.id == whisperBrowserModelID }) {
+            return
+        }
+
+        let preferredID = settings.selectedWhisperModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !preferredID.isEmpty,
+           filteredWhisperModels.contains(where: { $0.id == preferredID }) {
+            whisperBrowserModelID = preferredID
+            return
+        }
+
+        whisperBrowserModelID = filteredWhisperModels[0].id
+    }
+
+    private func ensureSelectedWhisperModelIsValid() {
+        if settings.transcriptionEngine != .whisperCpp {
+            return
+        }
+
+        if whisperModelManager.hasInstalledModel(id: settings.selectedWhisperModelID) {
+            return
+        }
+
+        if let firstInstalled = WhisperModelCatalog.curatedModels.first(where: { whisperModelManager.hasInstalledModel(id: $0.id) }) {
+            settings.selectedWhisperModelID = firstInstalled.id
+        } else {
+            settings.selectedWhisperModelID = ""
         }
     }
 
@@ -1445,25 +2242,28 @@ struct SettingsView: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(title)
-                .font(.headline)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
 
-            if let subtitle {
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
 
             content()
         }
         .padding(14)
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.95))
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.6))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.primary.opacity(0.10), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
         )
     }
 
@@ -1483,6 +2283,85 @@ struct SettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private func manualShortcutBuilder(for target: ShortcutCaptureTarget) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Manual map")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                ForEach(Self.shortcutModifierOptions) { option in
+                    Toggle(option.label, isOn: Binding(
+                        get: { manualShortcutHasModifier(option.flag, for: target) },
+                        set: { isEnabled in
+                            setManualShortcutModifier(option.flag, enabled: isEnabled, for: target)
+                        }
+                    ))
+                    .toggleStyle(.button)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Text("Primary key")
+                    .font(.callout.weight(.medium))
+                Picker("Primary key", selection: manualShortcutKeyBinding(for: target)) {
+                    Text("Modifier only")
+                        .tag(Self.manualModifierOnlyKeyCode)
+                    ForEach(manualShortcutKeyOptions) { option in
+                        Text(option.label)
+                            .tag(option.keyCode)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 210)
+                .labelsHidden()
+            }
+
+            Text("For modifier-only shortcuts, choose 2 to 4 modifiers and select \"Modifier only\".")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private func manualShortcutHasModifier(_ modifier: NSEvent.ModifierFlags, for target: ShortcutCaptureTarget) -> Bool {
+        ShortcutValidation.filteredModifierFlags(from: shortcutModifiersRaw(for: target)).contains(modifier)
+    }
+
+    private func setManualShortcutModifier(
+        _ modifier: NSEvent.ModifierFlags,
+        enabled: Bool,
+        for target: ShortcutCaptureTarget
+    ) {
+        var flags = ShortcutValidation.filteredModifierFlags(from: shortcutModifiersRaw(for: target))
+        if enabled {
+            flags.insert(modifier)
+        } else {
+            flags.remove(modifier)
+        }
+
+        _ = applyShortcutSelection(
+            for: target,
+            keyCode: shortcutKeyCode(for: target),
+            modifiersRaw: flags.rawValue,
+            validationMessage: "Shortcut must use 2 to 4 keys. Use 1-3 modifiers with a key, or 2-4 modifiers with \"Modifier only\"."
+        )
+    }
+
+    private func manualShortcutKeyBinding(for target: ShortcutCaptureTarget) -> Binding<UInt16> {
+        Binding(
+            get: { shortcutKeyCode(for: target) },
+            set: { newKeyCode in
+                _ = applyShortcutSelection(
+                    for: target,
+                    keyCode: newKeyCode,
+                    modifiersRaw: shortcutModifiersRaw(for: target),
+                    validationMessage: "Shortcut must use 2 to 4 keys. Use 1-3 modifiers with a key, or 2-4 modifiers with \"Modifier only\"."
+                )
+            }
+        )
+    }
+
     private var trimmedSearchQuery: String {
         searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
@@ -1491,19 +2370,28 @@ struct SettingsView: View {
         [
             .init(section: .general, title: "Accessibility access", detail: "Grant or verify accessibility permission", keywords: ["accessibility", "permission", "grant"]),
             .init(section: .general, title: "Copy transcript to clipboard", detail: "Automatically copy dictation results", keywords: ["clipboard", "copy", "output"]),
+            .init(section: .general, title: "Dictation sound profile", detail: "Choose tones for start, stop, processing, and pasted cues", keywords: ["sound", "start", "listening", "feedback", "processing", "stop", "pasted"]),
             .init(section: .general, title: "Waveform theme", detail: "Choose visual waveform style", keywords: ["waveform", "theme", "appearance"]),
             .init(section: .shortcuts, title: "Hold-to-talk shortcut", detail: "Set keys for press-and-hold dictation", keywords: ["hold", "shortcut", "keyboard"]),
+            .init(section: .shortcuts, title: "Mute shortcut system sounds", detail: "Optionally suppress beeps while hold-to-talk is pressed", keywords: ["mute", "beep", "sound", "hold", "shortcut"]),
+            .init(section: .shortcuts, title: "Manual shortcut map", detail: "Click modifiers and choose a key manually", keywords: ["manual", "map", "shortcut", "click", "keys"]),
             .init(section: .shortcuts, title: "Continuous toggle shortcut", detail: "Set keys for start/stop dictation mode", keywords: ["continuous", "toggle", "shortcut"]),
             .init(section: .shortcuts, title: "Paste last transcript", detail: "Reserved shortcut: ⌥⌘V", keywords: ["paste", "last transcript", "reserved"]),
             .init(section: .microphone, title: "Auto-detect microphone", detail: "Automatically use best available input", keywords: ["microphone", "input", "auto"]),
             .init(section: .microphone, title: "Microphone device picker", detail: "Choose a specific microphone manually", keywords: ["microphone", "device", "picker"]),
+            .init(section: .recognition, title: "Transcription engine", detail: "Switch between Apple Speech and whisper.cpp", keywords: ["engine", "whisper", "apple", "recognition"]),
             .init(section: .recognition, title: "Contextual language bias", detail: "Improve recognition with likely words", keywords: ["context", "bias", "recognition"]),
             .init(section: .recognition, title: "Preserve words across pauses", detail: "Prevent dropped words in short pauses", keywords: ["pause", "preserve", "recognition"]),
-            .init(section: .recognition, title: "Prefer on-device recognition", detail: "Favor local/private speech processing", keywords: ["on-device", "privacy", "recognition"]),
+            .init(section: .recognition, title: "Recognition mode", detail: "Choose local/cloud behavior for Apple Speech", keywords: ["on-device", "cloud", "privacy", "recognition"]),
             .init(section: .recognition, title: "Automatic punctuation", detail: "Enable punctuation from Apple Speech", keywords: ["punctuation", "speech"]),
             .init(section: .recognition, title: "Finalize delay", detail: "Control speed vs stability before insertion", keywords: ["delay", "finalize", "timing"]),
             .init(section: .recognition, title: "Cleanup mode", detail: "Light or aggressive text cleanup", keywords: ["cleanup", "mode"]),
             .init(section: .recognition, title: "Custom phrases", detail: "Add names, acronyms, and domain language", keywords: ["phrases", "vocabulary", "context"]),
+            .init(section: .models, title: "whisper model install", detail: "Download and manage all whisper.cpp models", keywords: ["model", "download", "whisper", "tiny", "base", "small", "medium", "large"]),
+            .init(section: .models, title: "whisper Core ML", detail: "Use Core ML encoder when available", keywords: ["core ml", "ane", "whisper", "speed"]),
+            .init(section: .corrections, title: "Adaptive corrections", detail: "Learn from your quick word/phrase fixes", keywords: ["adaptive", "learned", "corrections", "backspace"]),
+            .init(section: .corrections, title: "Correction learned sound", detail: "Choose a tone when a new correction is learned", keywords: ["sound", "beep", "feedback", "correction", "learned"]),
+            .init(section: .corrections, title: "Learned corrections list", detail: "View, remove, or clear saved corrections", keywords: ["learned", "list", "remove", "clear"]),
             .init(section: .about, title: "Permission overview", detail: "See accessibility, mic, and speech status", keywords: ["permissions", "accessibility", "microphone", "speech"]),
             .init(section: .about, title: "Crash logs", detail: "Open existing crash logs in Finder", keywords: ["crash", "logs", "diagnostics"]),
             .init(section: .about, title: "Uninstall KeyScribe", detail: "Remove app and clear saved settings", keywords: ["uninstall", "remove", "reset"])
@@ -1538,6 +2426,97 @@ struct SettingsView: View {
         return combined
     }
 
+    private var canSubmitCorrectionDraft: Bool {
+        !correctionSourceDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !correctionReplacementDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func openCreateCorrectionDialog() {
+        correctionEditingSource = nil
+        correctionSourceDraft = ""
+        correctionReplacementDraft = ""
+        correctionDialogMessage = nil
+        isCorrectionEditorPresented = true
+    }
+
+    private func beginEditingCorrection(_ correction: AdaptiveCorrectionStore.LearnedCorrection) {
+        correctionEditingSource = correction.source
+        correctionSourceDraft = correction.source
+        correctionReplacementDraft = correction.replacement
+        correctionDialogMessage = nil
+        isCorrectionEditorPresented = true
+    }
+
+    private func closeCorrectionEditorDialog() {
+        isCorrectionEditorPresented = false
+        correctionDialogMessage = nil
+        correctionEditingSource = nil
+        correctionSourceDraft = ""
+        correctionReplacementDraft = ""
+    }
+
+    private func submitCorrectionDraft() {
+        let originalEditingSource = correctionEditingSource
+        guard let saved = adaptiveCorrectionStore.upsertManualCorrection(
+            source: correctionSourceDraft,
+            replacement: correctionReplacementDraft
+        ) else {
+            correctionDialogMessage = "Enter both fields with real words."
+            return
+        }
+
+        if let originalEditingSource, originalEditingSource != saved.source {
+            adaptiveCorrectionStore.removeCorrection(source: originalEditingSource)
+        }
+
+        correctionDialogMessage = nil
+        correctionEditingSource = nil
+        correctionSourceDraft = ""
+        correctionReplacementDraft = ""
+        isCorrectionEditorPresented = false
+    }
+
+    @ViewBuilder
+    private var correctionEditorSheet: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(correctionEditingSource == nil ? "Add Custom Correction" : "Edit Correction")
+                .font(.title3.weight(.semibold))
+
+            Text("When KeyScribe hears")
+                .font(.callout.weight(.medium))
+            TextField("e.g. get ignored", text: $correctionSourceDraft)
+                .textFieldStyle(.roundedBorder)
+
+            Text("Replace with")
+                .font(.callout.weight(.medium))
+            TextField("e.g. gitignored", text: $correctionReplacementDraft)
+                .textFieldStyle(.roundedBorder)
+
+            if let correctionDialogMessage {
+                Text(correctionDialogMessage)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            HStack(spacing: 10) {
+                Spacer()
+                Button("Cancel") {
+                    closeCorrectionEditorDialog()
+                }
+                .buttonStyle(.bordered)
+
+                Button(correctionEditingSource == nil ? "Add Correction" : "Save Changes") {
+                    submitCorrectionDraft()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canSubmitCorrectionDraft)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+
     private func matchCount(for section: SettingsSection) -> Int {
         filteredSearchEntries.filter { $0.section == section }.count
     }
@@ -1566,8 +2545,7 @@ struct SettingsView: View {
 
                 if !settings.accessibilityTrusted {
                     Button("Grant Accessibility Access…") {
-                        settings.refreshAccessibilityStatus(prompt: true)
-                        openAccessibilitySettings()
+                        PermissionCenter.requestAccessibilityPermission(using: settings, promptIfNeeded: true)
                     }
                     .buttonStyle(.borderedProminent)
                 }
@@ -1587,9 +2565,12 @@ struct SettingsView: View {
         }
     }
 
-    private func openAccessibilitySettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else { return }
-        NSWorkspace.shared.open(url)
+    private func requestMicrophonePermission() {
+        PermissionCenter.requestMicrophonePermission(openSettingsIfDenied: true)
+    }
+
+    private func requestSpeechRecognitionPermission() {
+        PermissionCenter.requestSpeechRecognitionPermission(openSettingsIfDenied: true)
     }
 
     private var holdToTalkShortcutSegments: [String] {
@@ -1615,6 +2596,59 @@ struct SettingsView: View {
             keyCode: settings.continuousToggleShortcutKeyCode,
             modifiersRaw: settings.continuousToggleShortcutModifiers
         )
+    }
+
+    private func shortcutKeyCode(for target: ShortcutCaptureTarget) -> UInt16 {
+        switch target {
+        case .holdToTalk:
+            settings.shortcutKeyCode
+        case .continuousToggle:
+            settings.continuousToggleShortcutKeyCode
+        }
+    }
+
+    private func shortcutModifiersRaw(for target: ShortcutCaptureTarget) -> UInt {
+        switch target {
+        case .holdToTalk:
+            settings.shortcutModifiers
+        case .continuousToggle:
+            settings.continuousToggleShortcutModifiers
+        }
+    }
+
+    @discardableResult
+    private func applyShortcutSelection(
+        for target: ShortcutCaptureTarget,
+        keyCode: UInt16,
+        modifiersRaw: UInt,
+        validationMessage: String
+    ) -> Bool {
+        let filteredModifiers = ShortcutValidation.filteredModifierRawValue(from: modifiersRaw)
+        guard ShortcutValidation.isValid(keyCode: keyCode, modifiersRaw: filteredModifiers) else {
+            shortcutCaptureMessage = validationMessage
+            return false
+        }
+
+        if let conflictMessage = shortcutConflictMessage(
+            for: target,
+            keyCode: keyCode,
+            modifiersRaw: filteredModifiers
+        ) {
+            shortcutCaptureMessage = conflictMessage
+            return false
+        }
+
+        switch target {
+        case .holdToTalk:
+            settings.shortcutKeyCode = keyCode
+            settings.shortcutModifiers = filteredModifiers
+        case .continuousToggle:
+            settings.continuousToggleShortcutKeyCode = keyCode
+            settings.continuousToggleShortcutModifiers = filteredModifiers
+        }
+
+        shortcutCaptureMessage = nil
+        return true
     }
 
     private func beginShortcutCapture(for target: ShortcutCaptureTarget) {
@@ -1666,6 +2700,8 @@ struct SettingsView: View {
     @ViewBuilder
     private var aboutSection: some View {
         VStack(alignment: .leading, spacing: 16) {
+            settingsSectionHeader(for: .about)
+
             // Version info
             HStack(spacing: 10) {
                 Image(systemName: "app.badge.checkmark.fill")
@@ -1692,8 +2728,7 @@ struct SettingsView: View {
                     granted: settings.accessibilityTrusted,
                     hint: "Required for text insertion and global hotkeys",
                     action: {
-                        settings.refreshAccessibilityStatus(prompt: true)
-                        openAccessibilitySettings()
+                        PermissionCenter.requestAccessibilityPermission(using: settings, promptIfNeeded: true)
                     }
                 )
 
@@ -1702,20 +2737,18 @@ struct SettingsView: View {
                     granted: microphoneAuthorized,
                     hint: "Required to capture speech",
                     action: {
-                        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
-                            NSWorkspace.shared.open(url)
-                        }
+                        requestMicrophonePermission()
                     }
                 )
 
                 permissionRow(
                     name: "Speech Recognition",
-                    granted: speechRecognitionAuthorized,
-                    hint: "Required to transcribe speech to text",
+                    granted: settings.transcriptionEngine == .appleSpeech ? speechRecognitionAuthorized : true,
+                    hint: settings.transcriptionEngine == .appleSpeech
+                        ? "Required when Apple Speech engine is selected"
+                        : "Not required while whisper.cpp engine is selected",
                     action: {
-                        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition") {
-                            NSWorkspace.shared.open(url)
-                        }
+                        requestSpeechRecognitionPermission()
                     }
                 )
             }
@@ -1749,9 +2782,16 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Uninstall")
                     .font(.headline)
-                Text("Remove KeyScribe, reset all permissions (Accessibility, Microphone, Speech Recognition), and delete saved settings.")
+                Text("Remove KeyScribe, reset permissions, and clear local app data. You can optionally keep downloaded whisper models for faster re-testing.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Toggle("Also delete learned corrections", isOn: $uninstallDeleteLearnedCorrections)
+                    .toggleStyle(.switch)
+
+                Toggle("Also delete downloaded whisper models", isOn: $uninstallDeleteDownloadedModels)
+                    .toggleStyle(.switch)
+
                 Button(role: .destructive, action: {
                     showUninstallConfirmation = true
                 }) {
@@ -1761,17 +2801,27 @@ struct SettingsView: View {
                 .alert("Uninstall KeyScribe?", isPresented: $showUninstallConfirmation) {
                     Button("Cancel", role: .cancel) { }
                     Button("Uninstall", role: .destructive) {
-                        SettingsStore.resetAndUninstall()
+                        SettingsStore.resetAndUninstall(
+                            deleteDownloadedModels: uninstallDeleteDownloadedModels,
+                            deleteLearnedCorrections: uninstallDeleteLearnedCorrections
+                        )
                     }
                 } message: {
-                    Text("This will reset all permissions, delete your settings, and remove the app. You will be prompted for your admin password.")
+                    Text(uninstallSummaryText)
                 }
             }
 
-            Text("Built with Apple Speech framework · on-device recognition when available")
+            Text("Built with Apple Speech and whisper.cpp")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }
+    }
+
+    private var uninstallSummaryText: String {
+        let modelText = uninstallDeleteDownloadedModels ? "delete downloaded whisper models" : "keep downloaded whisper models"
+        let correctionText = uninstallDeleteLearnedCorrections ? "delete learned corrections" : "keep learned corrections"
+
+        return "This will reset permissions, remove settings, \(modelText), \(correctionText), and uninstall the app."
     }
 
     @ViewBuilder
@@ -1810,6 +2860,17 @@ struct SettingsView: View {
         SFSpeechRecognizer.authorizationStatus() == .authorized
     }
 
+}
+
+private extension WhisperModelManager.InstallState {
+    var installButtonTitle: String {
+        switch self {
+        case .failed:
+            return "Retry Install"
+        default:
+            return "Install"
+        }
+    }
 }
 
 
@@ -2059,6 +3120,8 @@ struct ShortcutCaptureMonitor: NSViewRepresentable {
         private var localKeyMonitor: Any?
         private var globalFlagsMonitor: Any?
         private var localFlagsMonitor: Any?
+        private var pendingModifierCaptureWorkItem: DispatchWorkItem?
+        private var pendingModifierCaptureFlags: NSEvent.ModifierFlags = []
         private var didCapture = false
 
         init(parent: ShortcutCaptureMonitor) {
@@ -2068,6 +3131,7 @@ struct ShortcutCaptureMonitor: NSViewRepresentable {
         func start() {
             guard globalKeyMonitor == nil, localKeyMonitor == nil, globalFlagsMonitor == nil, localFlagsMonitor == nil else { return }
             didCapture = false
+            cancelPendingModifierCapture()
 
             let mask = ShortcutValidation.supportedModifierFlags
 
@@ -2095,6 +3159,7 @@ struct ShortcutCaptureMonitor: NSViewRepresentable {
         @discardableResult
         private func handleKeyDown(_ event: NSEvent, mask: NSEvent.ModifierFlags) -> Bool {
             guard !didCapture else { return true }
+            cancelPendingModifierCapture()
 
             if event.keyCode == 53 { // Escape
                 didCapture = true
@@ -2126,13 +3191,34 @@ struct ShortcutCaptureMonitor: NSViewRepresentable {
 
             let capturedFlags = event.modifierFlags.intersection(mask)
             let count = ShortcutValidation.modifierCount(in: capturedFlags)
-            guard (2...3).contains(count) else { return false }
-
-            didCapture = true
-            DispatchQueue.main.async {
-                self.parent.onCapture(UInt16.max, capturedFlags.rawValue)
+            guard (2...4).contains(count) else {
+                cancelPendingModifierCapture()
+                return false
             }
+
+            scheduleModifierOnlyCapture(with: capturedFlags)
             return true
+        }
+
+        private func scheduleModifierOnlyCapture(with flags: NSEvent.ModifierFlags) {
+            cancelPendingModifierCapture()
+            pendingModifierCaptureFlags = flags
+
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self, !self.didCapture else { return }
+                let currentFlags = NSEvent.modifierFlags.intersection(ShortcutValidation.supportedModifierFlags)
+                guard currentFlags == self.pendingModifierCaptureFlags else { return }
+                self.didCapture = true
+                self.parent.onCapture(UInt16.max, self.pendingModifierCaptureFlags.rawValue)
+            }
+            pendingModifierCaptureWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: workItem)
+        }
+
+        private func cancelPendingModifierCapture() {
+            pendingModifierCaptureWorkItem?.cancel()
+            pendingModifierCaptureWorkItem = nil
+            pendingModifierCaptureFlags = []
         }
 
         func stop() {
@@ -2152,6 +3238,7 @@ struct ShortcutCaptureMonitor: NSViewRepresentable {
                 NSEvent.removeMonitor(localFlagsMonitor)
                 self.localFlagsMonitor = nil
             }
+            cancelPendingModifierCapture()
             didCapture = false
         }
 

--- a/Sources/KeyScribe/Services/AdaptiveCorrectionStore.swift
+++ b/Sources/KeyScribe/Services/AdaptiveCorrectionStore.swift
@@ -1,0 +1,422 @@
+import Foundation
+
+@MainActor
+final class AdaptiveCorrectionStore: ObservableObject {
+    struct LearnedCorrection: Codable, Identifiable, Hashable {
+        let source: String
+        var replacement: String
+        var learnCount: Int
+        var updatedAt: Date
+
+        var id: String { source }
+
+        var sourceTokenCount: Int {
+            source.split(separator: " ").count
+        }
+
+        var sourceTokens: [String] {
+            source.split(separator: " ").map(String.init)
+        }
+    }
+
+    struct LearningEvent: Equatable {
+        let source: String
+        let replacement: String
+        let learnCount: Int
+    }
+
+    struct AppliedEvent: Equatable {
+        let source: String
+        let replacement: String
+    }
+
+    struct ApplyResult: Equatable {
+        let text: String
+        let appliedEvents: [AppliedEvent]
+    }
+
+    static let shared = AdaptiveCorrectionStore()
+
+    @Published private(set) var learnedCorrections: [LearnedCorrection] = []
+
+    private let defaults = UserDefaults.standard
+    private static let legacyStorageKey = "KeyScribe.learnedCorrections.v1"
+    private static let storageFileName = "learned-corrections.json"
+    private static let fallbackStoragePath = "\(NSHomeDirectory())/Library/Application Support/KeyScribe/Models/\(storageFileName)"
+
+    private struct WordToken {
+        let original: String
+        let normalized: String
+        let range: Range<String.Index>
+    }
+
+    private static let wordRegex = try? NSRegularExpression(
+        pattern: "[A-Za-z0-9]+(?:[._'/-][A-Za-z0-9]+)*",
+        options: []
+    )
+
+    private init() {
+        load()
+    }
+
+    func apply(to text: String) -> String {
+        applyWithEvents(to: text).text
+    }
+
+    func applyWithEvents(to text: String) -> ApplyResult {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return ApplyResult(text: text, appliedEvents: []) }
+        guard !learnedCorrections.isEmpty else { return ApplyResult(text: text, appliedEvents: []) }
+
+        let tokens = tokenize(text)
+        guard !tokens.isEmpty else { return ApplyResult(text: text, appliedEvents: []) }
+
+        let sortedCorrections = learnedCorrections
+            .sorted {
+                if $0.sourceTokenCount != $1.sourceTokenCount {
+                    return $0.sourceTokenCount > $1.sourceTokenCount
+                }
+                if $0.learnCount != $1.learnCount {
+                    return $0.learnCount > $1.learnCount
+                }
+                return $0.updatedAt > $1.updatedAt
+            }
+
+        struct PendingReplacement {
+            let range: Range<String.Index>
+            let text: String
+            let event: AppliedEvent
+        }
+
+        var replacements: [PendingReplacement] = []
+        var index = 0
+
+        while index < tokens.count {
+            var matchedCorrection: LearnedCorrection?
+            var matchedLength = 0
+
+            for correction in sortedCorrections {
+                let sourceTokens = correction.sourceTokens
+                guard !sourceTokens.isEmpty else { continue }
+                guard index + sourceTokens.count <= tokens.count else { continue }
+
+                var isMatch = true
+                for offset in 0..<sourceTokens.count {
+                    if tokens[index + offset].normalized != sourceTokens[offset] {
+                        isMatch = false
+                        break
+                    }
+                }
+
+                if isMatch {
+                    matchedCorrection = correction
+                    matchedLength = sourceTokens.count
+                    break
+                }
+            }
+
+            if let correction = matchedCorrection {
+                let start = tokens[index].range.lowerBound
+                let end = tokens[index + matchedLength - 1].range.upperBound
+                let replacement = adaptReplacementCase(
+                    replacement: correction.replacement,
+                    sourceToken: tokens[index].original
+                )
+                replacements.append(
+                    PendingReplacement(
+                        range: start..<end,
+                        text: replacement,
+                        event: AppliedEvent(source: correction.source, replacement: correction.replacement)
+                    )
+                )
+                index += matchedLength
+            } else {
+                index += 1
+            }
+        }
+
+        guard !replacements.isEmpty else { return ApplyResult(text: text, appliedEvents: []) }
+
+        var updated = text
+        for replacement in replacements.reversed() {
+            updated.replaceSubrange(replacement.range, with: replacement.text)
+        }
+        return ApplyResult(
+            text: updated,
+            appliedEvents: replacements.map(\.event)
+        )
+    }
+
+    func preferredRecognitionPhrases(limit: Int = 40) -> [String] {
+        guard limit > 0 else { return [] }
+        guard !learnedCorrections.isEmpty else { return [] }
+
+        let prioritized = learnedCorrections.sorted {
+            if $0.learnCount != $1.learnCount {
+                return $0.learnCount > $1.learnCount
+            }
+            return $0.updatedAt > $1.updatedAt
+        }
+
+        var seen = Set<String>()
+        var phrases: [String] = []
+        phrases.reserveCapacity(min(limit, prioritized.count))
+
+        for correction in prioritized {
+            let replacement = correction.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !replacement.isEmpty else { continue }
+
+            let normalized = replacement.lowercased()
+            if seen.insert(normalized).inserted {
+                phrases.append(replacement)
+                if phrases.count == limit {
+                    break
+                }
+            }
+        }
+
+        return phrases
+    }
+
+    func learn(from originalText: String, correctedText: String, insertionHint: String? = nil) -> [LearningEvent] {
+        guard let candidate = extractCandidate(from: originalText, to: correctedText) else {
+            return []
+        }
+
+        let sourceTokenList = candidate.source.split(separator: " ").map(String.init)
+        let replacementTokenList = tokenize(candidate.replacement).map(\.normalized)
+
+        if let insertionHint, !insertionHint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let hintTokens = Set(tokenize(insertionHint).map(\.normalized))
+            let sourceTokens = Set(sourceTokenList)
+            if !hintTokens.isEmpty && sourceTokens.isDisjoint(with: hintTokens) {
+                // Keep the unrelated-edit guard for broad rewrites, but allow focused 1-2 word fixes.
+                if sourceTokenList.count > 2 || replacementTokenList.count > 3 {
+                    return []
+                }
+            }
+        }
+
+        if let existingIndex = learnedCorrections.firstIndex(where: { $0.source == candidate.source }) {
+            var existing = learnedCorrections[existingIndex]
+            existing.replacement = candidate.replacement
+            existing.learnCount += 1
+            existing.updatedAt = Date()
+            learnedCorrections[existingIndex] = existing
+
+            learnedCorrections.sort {
+                if $0.learnCount != $1.learnCount {
+                    return $0.learnCount > $1.learnCount
+                }
+                return $0.updatedAt > $1.updatedAt
+            }
+
+            persist()
+            return [LearningEvent(source: existing.source, replacement: existing.replacement, learnCount: existing.learnCount)]
+        }
+
+        let created = LearnedCorrection(
+            source: candidate.source,
+            replacement: candidate.replacement,
+            learnCount: 1,
+            updatedAt: Date()
+        )
+        learnedCorrections.insert(created, at: 0)
+        persist()
+
+        return [LearningEvent(source: created.source, replacement: created.replacement, learnCount: created.learnCount)]
+    }
+
+    @discardableResult
+    func upsertManualCorrection(source rawSource: String, replacement rawReplacement: String) -> LearnedCorrection? {
+        let source = normalizedSourceKey(from: rawSource)
+        let replacement = rawReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !source.isEmpty, !replacement.isEmpty else { return nil }
+        guard source.count >= 2, replacement.count >= 2 else { return nil }
+
+        if let existingIndex = learnedCorrections.firstIndex(where: { $0.source == source }) {
+            var existing = learnedCorrections[existingIndex]
+            existing.replacement = replacement
+            existing.updatedAt = Date()
+            if existing.learnCount < 1 {
+                existing.learnCount = 1
+            }
+            learnedCorrections[existingIndex] = existing
+            persist()
+            return existing
+        }
+
+        let created = LearnedCorrection(
+            source: source,
+            replacement: replacement,
+            learnCount: 1,
+            updatedAt: Date()
+        )
+        learnedCorrections.insert(created, at: 0)
+        persist()
+        return created
+    }
+
+    func removeCorrection(source: String) {
+        guard let index = learnedCorrections.firstIndex(where: { $0.source == source }) else { return }
+        learnedCorrections.remove(at: index)
+        persist()
+    }
+
+    func clearAll() {
+        guard !learnedCorrections.isEmpty else { return }
+        learnedCorrections.removeAll()
+        persist()
+    }
+
+    private func persist() {
+        if learnedCorrections.isEmpty {
+            if let fileURL = Self.storageFileURL() {
+                try? FileManager.default.removeItem(at: fileURL)
+            }
+            defaults.removeObject(forKey: Self.legacyStorageKey)
+            return
+        }
+
+        guard let data = try? JSONEncoder().encode(learnedCorrections) else {
+            return
+        }
+        guard let fileURL = Self.storageFileURL() else {
+            return
+        }
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            return
+        }
+    }
+
+    private func load() {
+        if let fileURL = Self.storageFileURL(),
+           let fileData = try? Data(contentsOf: fileURL),
+           let decoded = try? JSONDecoder().decode([LearnedCorrection].self, from: fileData) {
+            learnedCorrections = decoded.filter { correction in
+                !correction.source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+                    !correction.replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            if !learnedCorrections.isEmpty {
+                return
+            }
+        } else if let legacyData = defaults.data(forKey: Self.legacyStorageKey),
+                  let decoded = try? JSONDecoder().decode([LearnedCorrection].self, from: legacyData) {
+            learnedCorrections = decoded.filter { correction in
+                !correction.source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+                    !correction.replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            persist()
+            defaults.removeObject(forKey: Self.legacyStorageKey)
+            return
+        }
+
+        learnedCorrections = []
+    }
+
+    private func extractCandidate(from originalText: String, to correctedText: String) -> (source: String, replacement: String)? {
+        let oldTokens = tokenize(originalText)
+        let newTokens = tokenize(correctedText)
+
+        guard !oldTokens.isEmpty, !newTokens.isEmpty else { return nil }
+
+        var prefixCount = 0
+        while prefixCount < oldTokens.count,
+              prefixCount < newTokens.count,
+              oldTokens[prefixCount].normalized == newTokens[prefixCount].normalized {
+            prefixCount += 1
+        }
+
+        var oldSuffixStart = oldTokens.count
+        var newSuffixStart = newTokens.count
+
+        while oldSuffixStart > prefixCount,
+              newSuffixStart > prefixCount,
+              oldTokens[oldSuffixStart - 1].normalized == newTokens[newSuffixStart - 1].normalized {
+            oldSuffixStart -= 1
+            newSuffixStart -= 1
+        }
+
+        let oldChanged = Array(oldTokens[prefixCount..<oldSuffixStart])
+        let newChanged = Array(newTokens[prefixCount..<newSuffixStart])
+
+        guard !oldChanged.isEmpty, !newChanged.isEmpty else { return nil }
+
+        // Avoid learning from broad sentence rewrites or full clears.
+        if prefixCount == 0,
+           oldSuffixStart == oldTokens.count,
+           newSuffixStart == newTokens.count,
+           max(oldTokens.count, newTokens.count) > 6 {
+            return nil
+        }
+
+        guard oldChanged.count <= 4, newChanged.count <= 5 else {
+            return nil
+        }
+
+        let source = oldChanged.map(\.normalized).joined(separator: " ")
+        let replacement = newChanged.map(\.original).joined(separator: " ")
+
+        let normalizedReplacement = newChanged.map(\.normalized).joined(separator: " ")
+
+        guard source != normalizedReplacement else { return nil }
+        guard source.count >= 2, replacement.count >= 2 else { return nil }
+
+        return (source: source, replacement: replacement)
+    }
+
+    private func tokenize(_ text: String) -> [WordToken] {
+        guard let regex = Self.wordRegex else { return [] }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = regex.matches(in: text, options: [], range: range)
+
+        return matches.compactMap { match in
+            guard let tokenRange = Range(match.range, in: text) else {
+                return nil
+            }
+
+            let value = String(text[tokenRange])
+            let normalized = value.lowercased()
+            return WordToken(original: value, normalized: normalized, range: tokenRange)
+        }
+    }
+
+    private func normalizedSourceKey(from text: String) -> String {
+        tokenize(text).map(\.normalized).joined(separator: " ")
+    }
+
+    private func adaptReplacementCase(replacement: String, sourceToken: String) -> String {
+        guard let firstSource = sourceToken.first else { return replacement }
+        guard let firstReplacement = replacement.first else { return replacement }
+
+        if sourceToken == sourceToken.uppercased() {
+            return replacement.uppercased()
+        }
+
+        if firstSource.isUppercase, firstReplacement.isLowercase {
+            return firstReplacement.uppercased() + replacement.dropFirst()
+        }
+
+        return replacement
+    }
+
+    static func storageFilePath() -> String {
+        fallbackStoragePath
+    }
+
+    private static func storageFileURL() -> URL? {
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return appSupport
+            .appendingPathComponent("KeyScribe", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent(storageFileName)
+    }
+}

--- a/Sources/KeyScribe/Services/AppleSpeechTranscriber.swift
+++ b/Sources/KeyScribe/Services/AppleSpeechTranscriber.swift
@@ -1,0 +1,526 @@
+import AVFoundation
+import CoreAudio
+import Foundation
+import Speech
+
+final class AppleSpeechTranscriber: NSObject {
+    var onFinalText: ((String) -> Void)?
+    var onStatusUpdate: ((String) -> Void)?
+    var onAudioLevel: ((Float) -> Void)?
+    var onRecordingStateChange: ((Bool) -> Void)?
+
+    private let audioEngine = AVAudioEngine()
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionEngine: SFSpeechRecognizer?
+    private var pendingFinalizeWorkItem: DispatchWorkItem?
+
+    private var granted = false
+    private(set) var isRecording: Bool = false
+    private var isStopping: Bool = false
+    private var committedTranscript = ""
+    private var liveTranscript = ""
+    private var bestTranscriptInCurrentSegment = ""
+    private var previousDefaultInputDevice: AudioDeviceID?
+
+    private var autoDetectMicrophone = true
+    private var selectedMicrophoneUID = ""
+    private var enableContextualBias = true
+    private var keepTextAcrossPauses = true
+    private var recognitionMode: RecognitionMode = .localOnly
+    private var finalizeDelaySeconds: TimeInterval = 0.35
+    private var customContextPhrases: [String] = []
+    private var adaptiveBiasPhrases: [String] = []
+    private var autoPunctuation = true
+
+    override init() {
+        let locale = Locale.current
+        self.recognitionEngine = SFSpeechRecognizer(locale: locale)
+        super.init()
+    }
+
+    func requestPermissions(promptIfNeeded: Bool = true) {
+        if Thread.isMainThread {
+            requestPermissionsOnMain(promptIfNeeded: promptIfNeeded)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.requestPermissionsOnMain(promptIfNeeded: promptIfNeeded)
+            }
+        }
+    }
+
+    func applyMicrophoneSettings(autoDetect: Bool, microphoneUID: String) {
+        if Thread.isMainThread {
+            applyMicrophoneSettingsOnMain(autoDetect: autoDetect, microphoneUID: microphoneUID)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.applyMicrophoneSettingsOnMain(autoDetect: autoDetect, microphoneUID: microphoneUID)
+            }
+        }
+    }
+
+    func applyRecognitionSettings(
+        enableContextualBias: Bool,
+        keepTextAcrossPauses: Bool,
+        recognitionMode: RecognitionMode,
+        autoPunctuation: Bool,
+        finalizeDelaySeconds: TimeInterval,
+        customContextPhrases: String,
+        adaptiveBiasPhrases: [String]
+    ) {
+        if Thread.isMainThread {
+            applyRecognitionSettingsOnMain(
+                enableContextualBias: enableContextualBias,
+                keepTextAcrossPauses: keepTextAcrossPauses,
+                recognitionMode: recognitionMode,
+                autoPunctuation: autoPunctuation,
+                finalizeDelaySeconds: finalizeDelaySeconds,
+                customContextPhrases: customContextPhrases,
+                adaptiveBiasPhrases: adaptiveBiasPhrases
+            )
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.applyRecognitionSettingsOnMain(
+                    enableContextualBias: enableContextualBias,
+                    keepTextAcrossPauses: keepTextAcrossPauses,
+                    recognitionMode: recognitionMode,
+                    autoPunctuation: autoPunctuation,
+                    finalizeDelaySeconds: finalizeDelaySeconds,
+                    customContextPhrases: customContextPhrases,
+                    adaptiveBiasPhrases: adaptiveBiasPhrases
+                )
+            }
+        }
+    }
+
+    private func requestPermissionsOnMain(promptIfNeeded: Bool) {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            requestAudioPermissionIfNeededOnMain(promptIfNeeded: promptIfNeeded)
+
+        case .notDetermined:
+            guard promptIfNeeded else {
+                granted = false
+                return
+            }
+
+            SFSpeechRecognizer.requestAuthorization { [weak self] status in
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    switch status {
+                    case .authorized:
+                        self.requestAudioPermissionIfNeededOnMain(promptIfNeeded: promptIfNeeded)
+                    default:
+                        self.granted = false
+                        self.update("Speech permission not granted")
+                    }
+                }
+            }
+
+        default:
+            granted = false
+            update("Speech permission not granted")
+        }
+    }
+
+    private func applyMicrophoneSettingsOnMain(autoDetect: Bool, microphoneUID: String) {
+        autoDetectMicrophone = autoDetect
+        selectedMicrophoneUID = microphoneUID
+    }
+
+    private func applyRecognitionSettingsOnMain(
+        enableContextualBias: Bool,
+        keepTextAcrossPauses: Bool,
+        recognitionMode: RecognitionMode,
+        autoPunctuation: Bool,
+        finalizeDelaySeconds: TimeInterval,
+        customContextPhrases: String,
+        adaptiveBiasPhrases: [String]
+    ) {
+        self.enableContextualBias = enableContextualBias
+        self.keepTextAcrossPauses = keepTextAcrossPauses
+        self.recognitionMode = recognitionMode
+        self.autoPunctuation = autoPunctuation
+        self.finalizeDelaySeconds = RecognitionTuning.clampedFinalizeDelay(finalizeDelaySeconds)
+        self.customContextPhrases = RecognitionTuning.parseCustomPhrases(customContextPhrases)
+        self.adaptiveBiasPhrases = adaptiveBiasPhrases
+    }
+
+    private func requestAudioPermissionIfNeededOnMain(promptIfNeeded: Bool) {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            granted = true
+            update("Permissions ready")
+
+        case .notDetermined:
+            guard promptIfNeeded else {
+                granted = false
+                return
+            }
+
+            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    if granted {
+                        self.granted = true
+                        self.update("Permissions ready")
+                    } else {
+                        self.granted = false
+                        self.update("Microphone permission not granted")
+                    }
+                }
+            }
+
+        default:
+            granted = false
+            update("Microphone permission not granted")
+        }
+    }
+
+    private func update(_ message: String) {
+        if Thread.isMainThread {
+            onStatusUpdate?(message)
+        } else {
+            DispatchQueue.main.async {
+                self.onStatusUpdate?(message)
+            }
+        }
+    }
+
+    @discardableResult
+    func startRecording() -> Bool {
+        if Thread.isMainThread {
+            return startRecordingOnMain()
+        }
+
+        return DispatchQueue.main.sync {
+            startRecordingOnMain()
+        }
+    }
+
+    func stopRecording(emitFinalText: Bool = true) {
+        if Thread.isMainThread {
+            stopRecordingOnMain(emitFinalText: emitFinalText)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.stopRecordingOnMain(emitFinalText: emitFinalText)
+            }
+        }
+    }
+
+    @discardableResult
+    private func startRecordingOnMain() -> Bool {
+        guard granted else {
+            // Re-check/request permissions on demand so first-run users are not stuck.
+            requestPermissionsOnMain(promptIfNeeded: true)
+            update("Permissions missing")
+            return false
+        }
+
+        guard !isRecording && !isStopping else { return false }
+        guard let recognitionEngine else {
+            update("No speech recognizer for locale")
+            return false
+        }
+        guard recognitionEngine.isAvailable else {
+            update("Speech recognizer unavailable")
+            return false
+        }
+
+        applyMicSelection()
+
+        pendingFinalizeWorkItem?.cancel()
+        pendingFinalizeWorkItem = nil
+        isStopping = false
+
+        committedTranscript = ""
+        liveTranscript = ""
+        bestTranscriptInCurrentSegment = ""
+        isRecording = true
+        onRecordingStateChange?(true)
+
+        guard startRecognitionTask() else {
+            isRecording = false
+            onRecordingStateChange?(false)
+            return false
+        }
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        let activeRecognitionRequest = recognitionRequest
+
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            activeRecognitionRequest?.append(buffer)
+            guard let self else { return }
+
+            let audioLevel = self.normalizedAudioLevel(from: buffer)
+            DispatchQueue.main.async {
+                self.onAudioLevel?(audioLevel)
+            }
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            update("Listening…")
+            return true
+        } catch {
+            update("Audio setup failed: \(error.localizedDescription)")
+            stopRecordingOnMain(emitFinalText: false)
+            return false
+        }
+    }
+
+    private func stopRecordingOnMain(emitFinalText: Bool = true) {
+        guard isRecording || isStopping else {
+            onAudioLevel?(0)
+            onRecordingStateChange?(false)
+            return
+        }
+
+        if isRecording {
+            isRecording = false
+            isStopping = true
+            onRecordingStateChange?(false)
+
+            recognitionRequest?.endAudio()
+
+            audioEngine.inputNode.removeTap(onBus: 0)
+            audioEngine.stop()
+            onAudioLevel?(0)
+        }
+
+        pendingFinalizeWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.finalizeStop(emitFinalText: emitFinalText)
+        }
+        pendingFinalizeWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + finalizeDelaySeconds, execute: workItem)
+    }
+
+    private func finalizeStop(emitFinalText: Bool) {
+        pendingFinalizeWorkItem = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        restoreMicSelection()
+
+        let text = mergedTranscript().trimmingCharacters(in: .whitespacesAndNewlines)
+        committedTranscript = ""
+        liveTranscript = ""
+        bestTranscriptInCurrentSegment = ""
+        isStopping = false
+
+        update("Ready")
+
+        if emitFinalText && !text.isEmpty {
+            onFinalText?(text)
+        }
+    }
+
+    private func startRecognitionTask() -> Bool {
+        guard let recognitionEngine else {
+            update("No speech recognizer for locale")
+            return false
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        if #available(macOS 13, *) {
+            switch recognitionMode {
+            case .localOnly:
+                request.requiresOnDeviceRecognition = true
+            case .cloudOnly, .automatic:
+                request.requiresOnDeviceRecognition = false
+            }
+            request.addsPunctuation = autoPunctuation
+        }
+        request.taskHint = .dictation
+        if enableContextualBias {
+            let defaults = [
+                "KeyScribe",
+                "OpenClaw",
+                "dictation",
+                "transcription",
+                "macOS"
+            ]
+            request.contextualStrings = RecognitionTuning.contextualHints(
+                defaults: defaults,
+                adaptive: adaptiveBiasPhrases,
+                custom: customContextPhrases,
+                limit: 80
+            )
+        }
+
+        bestTranscriptInCurrentSegment = ""
+
+        recognitionRequest = request
+        recognitionTask = recognitionEngine.recognitionTask(with: request) { [weak self] result, error in
+            DispatchQueue.main.async { [weak self] in
+                self?.handleRecognitionCallback(result: result, error: error)
+            }
+        }
+
+        return true
+    }
+
+    private func handleRecognitionCallback(result: SFSpeechRecognitionResult?, error: Error?) {
+        guard isRecording || isStopping else { return }
+
+        if let error {
+            let nsError = error as NSError
+            // Ignore expected cancellation noise when we stop/restart the task intentionally.
+            if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 216 {
+                return
+            }
+            if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+                return
+            }
+
+            update("Error: \(error.localizedDescription)")
+            stopRecordingOnMain(emitFinalText: false)
+            return
+        }
+
+        guard let result else { return }
+        let candidate = result.bestTranscription.formattedString
+        liveTranscript = candidate
+
+        if keepTextAcrossPauses {
+            updateBestTranscriptForCurrentSegment(with: candidate)
+        }
+
+        if result.isFinal {
+            if keepTextAcrossPauses {
+                commitBestSegmentTranscript()
+            } else {
+                commitLiveTranscript()
+            }
+
+            if isRecording {
+                _ = startRecognitionTask()
+            }
+        }
+    }
+
+    private func updateBestTranscriptForCurrentSegment(with candidate: String) {
+        let candidateText = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        let existingText = bestTranscriptInCurrentSegment.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !candidateText.isEmpty else { return }
+
+        if RecognitionTuning.scoreTranscript(candidateText) >= RecognitionTuning.scoreTranscript(existingText) {
+            bestTranscriptInCurrentSegment = candidateText
+        }
+    }
+
+    private func commitBestSegmentTranscript() {
+        let fallback = liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let best = bestTranscriptInCurrentSegment.trimmingCharacters(in: .whitespacesAndNewlines)
+        let chunk = RecognitionTuning.chooseBetterTranscript(primary: best, fallback: fallback)
+
+        guard !chunk.isEmpty else {
+            liveTranscript = ""
+            bestTranscriptInCurrentSegment = ""
+            return
+        }
+
+        if committedTranscript.isEmpty {
+            committedTranscript = chunk
+        } else {
+            committedTranscript += " " + chunk
+        }
+
+        liveTranscript = ""
+        bestTranscriptInCurrentSegment = ""
+    }
+
+    private func commitLiveTranscript() {
+        let chunk = liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !chunk.isEmpty else { return }
+
+        if committedTranscript.isEmpty {
+            committedTranscript = chunk
+        } else {
+            committedTranscript += " " + chunk
+        }
+        liveTranscript = ""
+        bestTranscriptInCurrentSegment = ""
+    }
+
+    private func mergedTranscript() -> String {
+        let current = liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let best = bestTranscriptInCurrentSegment.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tail = RecognitionTuning.chooseBetterTranscript(primary: best, fallback: current)
+
+        if committedTranscript.isEmpty { return tail }
+        if tail.isEmpty { return committedTranscript }
+        return committedTranscript + " " + tail
+    }
+
+    private func applyMicSelection() {
+        guard !autoDetectMicrophone else {
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        guard !selectedMicrophoneUID.isEmpty else {
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        guard let selectedDeviceID = MicrophoneManager.deviceID(forUID: selectedMicrophoneUID) else {
+            update("Selected microphone no longer available")
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        guard let currentDefault = MicrophoneManager.defaultInputDeviceID() else {
+            update("Unable to read default microphone")
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        if currentDefault == selectedDeviceID {
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        let changed = MicrophoneManager.setDefaultInput(deviceID: selectedDeviceID)
+        if changed {
+            previousDefaultInputDevice = currentDefault
+        } else {
+            update("Could not switch microphone")
+            previousDefaultInputDevice = nil
+        }
+    }
+
+    private func restoreMicSelection() {
+        guard let previous = previousDefaultInputDevice else { return }
+        _ = MicrophoneManager.setDefaultInput(deviceID: previous)
+        previousDefaultInputDevice = nil
+    }
+
+    private func normalizedAudioLevel(from buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData else {
+            return 0
+        }
+
+        let channelSamples = channelData.pointee
+        let frameCount = Int(buffer.frameLength)
+        guard frameCount > 0 else { return 0 }
+
+        var sum: Float = 0
+        for i in 0..<frameCount {
+            let sample = channelSamples[i]
+            sum += sample * sample
+        }
+
+        let meanSquare = sum / Float(frameCount)
+        let rms = sqrtf(max(meanSquare, 1e-12))
+        let db = 20 * log10f(rms)
+        let normalized = (db + 70) / 70
+        return max(0, min(1, normalized))
+    }
+}

--- a/Sources/KeyScribe/Services/CrashReporter.swift
+++ b/Sources/KeyScribe/Services/CrashReporter.swift
@@ -48,12 +48,19 @@ enum CrashReporter {
     }
 
 
+    /// Log a non-fatal informational event for diagnostics.
+    static func logInfo(_ message: String, file: String = #file, line: Int = #line) {
+        appendStructuredLog(level: "INFO", message: message, file: file, line: line)
+    }
+
+    /// Log a non-fatal warning for diagnostics.
+    static func logWarning(_ message: String, file: String = #file, line: Int = #line) {
+        appendStructuredLog(level: "WARN", message: message, file: file, line: line)
+    }
+
     /// Log a non-fatal error for diagnostics.
     static func logError(_ message: String, file: String = #file, line: Int = #line) {
-        let entry = """
-        [ERROR] \(ISO8601DateFormatter().string(from: Date())) \(URL(fileURLWithPath: file).lastPathComponent):\(line) \(message)
-        """
-        appendToLog(entry)
+        appendStructuredLog(level: "ERROR", message: message, file: file, line: line)
     }
 
     /// Returns the crash log URL, or nil if no logs exist.
@@ -114,5 +121,12 @@ enum CrashReporter {
         } else {
             try? Data(line.utf8).write(to: fileURL, options: .atomic)
         }
+    }
+
+    private static func appendStructuredLog(level: String, message: String, file: String, line: Int) {
+        let entry = """
+        [\(level)] \(ISO8601DateFormatter().string(from: Date())) \(URL(fileURLWithPath: file).lastPathComponent):\(line) \(message)
+        """
+        appendToLog(entry)
     }
 }

--- a/Sources/KeyScribe/Services/HotkeyManager.swift
+++ b/Sources/KeyScribe/Services/HotkeyManager.swift
@@ -1,6 +1,124 @@
 import AppKit
 import Foundation
 
+private final class ShortcutEventSuppressor {
+    private static let supportedModifiers: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
+
+    private let keyCode: UInt16
+    private let modifiers: NSEvent.ModifierFlags
+    private let onSuppressedKeyDown: () -> Void
+    private let onSuppressedKeyUp: () -> Void
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    init(
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        onSuppressedKeyDown: @escaping () -> Void,
+        onSuppressedKeyUp: @escaping () -> Void
+    ) {
+        self.keyCode = keyCode
+        self.modifiers = modifiers.intersection(Self.supportedModifiers)
+        self.onSuppressedKeyDown = onSuppressedKeyDown
+        self.onSuppressedKeyUp = onSuppressedKeyUp
+    }
+
+    func start() {
+        stop()
+
+        let eventsOfInterest = (CGEventMask(1) << CGEventType.keyDown.rawValue) | (CGEventMask(1) << CGEventType.keyUp.rawValue)
+        let callback: CGEventTapCallBack = { _, type, event, userInfo in
+            guard let userInfo else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let suppressor = Unmanaged<ShortcutEventSuppressor>.fromOpaque(userInfo).takeUnretainedValue()
+
+            if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                if let tap = suppressor.eventTap {
+                    CGEvent.tapEnable(tap: tap, enable: true)
+                }
+                return Unmanaged.passUnretained(event)
+            }
+
+            guard type == .keyDown || type == .keyUp else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            guard suppressor.shouldSuppress(event) else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            suppressor.notifySuppressedEvent(type)
+            return nil
+        }
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventsOfInterest,
+            callback: callback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else {
+            return
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        eventTap = tap
+        runLoopSource = source
+
+        if let source {
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    func stop() {
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            runLoopSource = nil
+        }
+
+        if let tap = eventTap {
+            CFMachPortInvalidate(tap)
+            eventTap = nil
+        }
+    }
+
+    private func shouldSuppress(_ event: CGEvent) -> Bool {
+        let eventKeyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        guard eventKeyCode == keyCode else { return false }
+
+        let eventModifiers = normalizedModifiers(from: event.flags)
+        return eventModifiers.isSuperset(of: modifiers)
+    }
+
+    private func notifySuppressedEvent(_ type: CGEventType) {
+        DispatchQueue.main.async {
+            switch type {
+            case .keyDown:
+                self.onSuppressedKeyDown()
+            case .keyUp:
+                self.onSuppressedKeyUp()
+            default:
+                break
+            }
+        }
+    }
+
+    private func normalizedModifiers(from flags: CGEventFlags) -> NSEvent.ModifierFlags {
+        var result: NSEvent.ModifierFlags = []
+        if flags.contains(.maskCommand) { result.insert(.command) }
+        if flags.contains(.maskAlternate) { result.insert(.option) }
+        if flags.contains(.maskControl) { result.insert(.control) }
+        if flags.contains(.maskShift) { result.insert(.shift) }
+        if flags.contains(.maskSecondaryFn) { result.insert(.function) }
+        return result.intersection(Self.supportedModifiers)
+    }
+}
+
 final class HoldToTalkManager {
     typealias Action = () -> Void
 
@@ -8,6 +126,7 @@ final class HoldToTalkManager {
 
     private let keyCode: UInt16
     private let modifiers: NSEvent.ModifierFlags
+    private let suppressSystemShortcutSounds: Bool
     private let onStart: Action
     private let onStop: Action
 
@@ -18,15 +137,23 @@ final class HoldToTalkManager {
     private var localKeyUpMonitor: Any?
     private var localFlagsMonitor: Any?
     private var releaseWatchdog: DispatchSourceTimer?
+    private var shortcutEventSuppressor: ShortcutEventSuppressor?
     private var active = false
 
     private var isModifierOnlyShortcut: Bool {
         keyCode == UInt16.max
     }
 
-    init(keyCode: UInt16, modifiers: NSEvent.ModifierFlags, onStart: @escaping Action, onStop: @escaping Action) {
+    init(
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        suppressSystemShortcutSounds: Bool = false,
+        onStart: @escaping Action,
+        onStop: @escaping Action
+    ) {
         self.keyCode = keyCode
         self.modifiers = modifiers.intersection(Self.supportedModifiers)
+        self.suppressSystemShortcutSounds = suppressSystemShortcutSounds
         self.onStart = onStart
         self.onStop = onStop
     }
@@ -69,6 +196,7 @@ final class HoldToTalkManager {
         }
 
         if isModifierOnlyShortcut {
+            stopShortcutEventSuppression()
             return
         }
 
@@ -91,6 +219,8 @@ final class HoldToTalkManager {
             self?.handle(event: event, isDown: false)
             return event
         }
+
+        startShortcutEventSuppressionIfNeeded()
     }
 
     private func stopOnMain() {
@@ -118,6 +248,7 @@ final class HoldToTalkManager {
             NSEvent.removeMonitor(localFlagsMonitor)
             self.localFlagsMonitor = nil
         }
+        stopShortcutEventSuppression()
         stopWatchdog()
         active = false
     }
@@ -193,6 +324,45 @@ final class HoldToTalkManager {
     private func stopWatchdog() {
         releaseWatchdog?.cancel()
         releaseWatchdog = nil
+    }
+
+    private func startShortcutEventSuppressionIfNeeded() {
+        guard suppressSystemShortcutSounds, !isModifierOnlyShortcut else {
+            stopShortcutEventSuppression()
+            return
+        }
+
+        let suppressor = ShortcutEventSuppressor(
+            keyCode: keyCode,
+            modifiers: modifiers,
+            onSuppressedKeyDown: { [weak self] in
+                self?.handleSuppressedShortcutEvent(isDown: true)
+            },
+            onSuppressedKeyUp: { [weak self] in
+                self?.handleSuppressedShortcutEvent(isDown: false)
+            }
+        )
+        suppressor.start()
+        shortcutEventSuppressor = suppressor
+    }
+
+    private func stopShortcutEventSuppression() {
+        shortcutEventSuppressor?.stop()
+        shortcutEventSuppressor = nil
+    }
+
+    private func handleSuppressedShortcutEvent(isDown: Bool) {
+        if isDown {
+            guard !active else { return }
+            active = true
+            startWatchdog()
+            onStart()
+        } else {
+            guard active else { return }
+            active = false
+            stopWatchdog()
+            onStop()
+        }
     }
 
     private func isShortcutPhysicallyHeld() -> Bool {

--- a/Sources/KeyScribe/Services/PostInsertCorrectionMonitor.swift
+++ b/Sources/KeyScribe/Services/PostInsertCorrectionMonitor.swift
@@ -1,0 +1,272 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class PostInsertCorrectionMonitor {
+    struct SessionResult {
+        let originalText: String
+        let correctedText: String
+        let insertedText: String
+    }
+
+    var onCorrectionDetected: ((SessionResult) -> Void)?
+
+    private struct Session {
+        let insertedText: String
+        let focusedElement: AXUIElement?
+        let baselineText: String?
+        let startedAt: Date
+        var lastActivityAt: Date
+        var sawEditIntent: Bool
+    }
+
+    private enum Constants {
+        static let idleTimeout: TimeInterval = 3.5
+        static let maxSessionDuration: TimeInterval = 15.0
+        static let timerTick: TimeInterval = 0.25
+        static let returnKeyCodes: Set<UInt16> = [36, 76]
+        static let deleteKeyCodes: Set<UInt16> = [51, 117]
+        static let navigationKeyCodes: Set<UInt16> = [123, 124, 125, 126, 115, 116, 119, 121]
+    }
+
+    private var globalKeyMonitor: Any?
+    private var globalMouseMonitor: Any?
+    private var sessionTimer: DispatchSourceTimer?
+    private var session: Session?
+
+    func startMonitoring(insertedText: String) {
+        let trimmed = insertedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        stopMonitoring(commitSession: false)
+
+        let focusedElement = focusedTextElement()
+        let baselineText = focusedElement.flatMap(readTextValue(for:))
+        let now = Date()
+        session = Session(
+            insertedText: trimmed,
+            focusedElement: focusedElement,
+            baselineText: baselineText,
+            startedAt: now,
+            lastActivityAt: now,
+            sawEditIntent: false
+        )
+
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            Task { @MainActor in
+                self?.handleKeyDown(event)
+            }
+        }
+
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.markActivity()
+            }
+        }
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + Constants.timerTick, repeating: Constants.timerTick)
+        timer.setEventHandler { [weak self] in
+            self?.tick()
+        }
+        sessionTimer = timer
+        timer.resume()
+    }
+
+    func stopMonitoring(commitSession: Bool = true) {
+        finishSession(commit: commitSession)
+    }
+
+    private func markActivity() {
+        guard var activeSession = session else { return }
+        activeSession.lastActivityAt = Date()
+        session = activeSession
+    }
+
+    private func handleKeyDown(_ event: NSEvent) {
+        guard var activeSession = session else { return }
+
+        activeSession.lastActivityAt = Date()
+
+        if event.keyCode == 53 { // Escape
+            session = activeSession
+            finishSession(commit: false)
+            return
+        }
+
+        if Constants.returnKeyCodes.contains(event.keyCode) {
+            activeSession.sawEditIntent = true
+            session = activeSession
+            finishSession(commit: true)
+            return
+        }
+
+        if didLikelyEditText(event) {
+            activeSession.sawEditIntent = true
+        }
+
+        session = activeSession
+    }
+
+    private func didLikelyEditText(_ event: NSEvent) -> Bool {
+        if Constants.deleteKeyCodes.contains(event.keyCode) {
+            return true
+        }
+
+        if Constants.navigationKeyCodes.contains(event.keyCode) {
+            return false
+        }
+
+        let modifiers = event.modifierFlags.intersection([.command, .option, .control, .function])
+        if modifiers.contains(.command) {
+            let key = (event.charactersIgnoringModifiers ?? "").lowercased()
+            return key == "v" || key == "x" || key == "z"
+        }
+
+        if modifiers.contains(.option) || modifiers.contains(.control) || modifiers.contains(.function) {
+            return false
+        }
+
+        guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else {
+            return false
+        }
+
+        return chars.unicodeScalars.contains { scalar in
+            !CharacterSet.controlCharacters.contains(scalar)
+        }
+    }
+
+    private func tick() {
+        guard let activeSession = session else {
+            finishSession(commit: false)
+            return
+        }
+
+        let now = Date()
+        if now.timeIntervalSince(activeSession.startedAt) >= Constants.maxSessionDuration {
+            finishSession(commit: true)
+            return
+        }
+
+        if now.timeIntervalSince(activeSession.lastActivityAt) >= Constants.idleTimeout {
+            finishSession(commit: true)
+        }
+    }
+
+    private func finishSession(commit: Bool) {
+        if let globalKeyMonitor {
+            NSEvent.removeMonitor(globalKeyMonitor)
+            self.globalKeyMonitor = nil
+        }
+
+        if let globalMouseMonitor {
+            NSEvent.removeMonitor(globalMouseMonitor)
+            self.globalMouseMonitor = nil
+        }
+
+        sessionTimer?.cancel()
+        sessionTimer = nil
+
+        guard let completedSession = session else {
+            return
+        }
+
+        session = nil
+
+        guard commit else {
+            return
+        }
+
+        let original = normalizedReferenceText(for: completedSession)
+        guard !original.isEmpty else { return }
+
+        guard let latest = latestFocusedText(for: completedSession) else { return }
+        let corrected = latest.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !corrected.isEmpty, corrected != original else { return }
+
+        // If no editing key events were seen, still allow learning only when text changed materially.
+        if !completedSession.sawEditIntent {
+            let distance = abs(corrected.count - original.count)
+            if distance <= 1 {
+                return
+            }
+        }
+
+        onCorrectionDetected?(
+            SessionResult(
+                originalText: original,
+                correctedText: corrected,
+                insertedText: completedSession.insertedText
+            )
+        )
+    }
+
+    private func normalizedReferenceText(for session: Session) -> String {
+        if let baseline = session.baselineText?.trimmingCharacters(in: .whitespacesAndNewlines), !baseline.isEmpty {
+            return baseline
+        }
+        return session.insertedText
+    }
+
+    private func latestFocusedText(for session: Session) -> String? {
+        if let focusedElement = session.focusedElement,
+           let value = readTextValue(for: focusedElement) {
+            return value
+        }
+
+        if let focusedElement = focusedTextElement(),
+           let value = readTextValue(for: focusedElement) {
+            return value
+        }
+
+        return nil
+    }
+
+    private func readTextValue(for element: AXUIElement) -> String? {
+        var valueRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            element,
+            kAXValueAttribute as CFString,
+            &valueRef
+        )
+
+        guard result == .success, let stringValue = valueRef as? String else {
+            return nil
+        }
+
+        return stringValue
+    }
+
+    private func focusedTextElement() -> AXUIElement? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedRef: CFTypeRef?
+        let focusedResult = AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedRef
+        )
+
+        guard focusedResult == .success, let focusedRef else {
+            return nil
+        }
+
+        guard CFGetTypeID(focusedRef) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        return unsafeBitCast(focusedRef, to: AXUIElement.self)
+    }
+
+    deinit {
+        if let globalKeyMonitor {
+            NSEvent.removeMonitor(globalKeyMonitor)
+        }
+        if let globalMouseMonitor {
+            NSEvent.removeMonitor(globalMouseMonitor)
+        }
+        sessionTimer?.cancel()
+    }
+}

--- a/Sources/KeyScribe/Services/RecognitionTuning.swift
+++ b/Sources/KeyScribe/Services/RecognitionTuning.swift
@@ -23,13 +23,13 @@ enum RecognitionTuning {
         return scoreTranscript(a) >= scoreTranscript(b) ? a : b
     }
 
-    static func contextualHints(defaults: [String], custom: [String], limit: Int = 80) -> [String] {
+    static func contextualHints(defaults: [String], adaptive: [String] = [], custom: [String], limit: Int = 80) -> [String] {
         guard limit > 0 else { return [] }
 
         var seen = Set<String>()
         var ordered: [String] = []
 
-        for phrase in defaults + custom {
+        for phrase in adaptive + defaults + custom {
             let normalized = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !normalized.isEmpty else { continue }
             if seen.insert(normalized).inserted {
@@ -41,5 +41,43 @@ enum RecognitionTuning {
         }
 
         return ordered
+    }
+
+    static func whisperBiasPhrases(
+        customContextPhrases: String,
+        adaptiveBiasPhrases: [String],
+        limit: Int = 48
+    ) -> [String] {
+        contextualHints(
+            defaults: [],
+            adaptive: adaptiveBiasPhrases,
+            custom: parseCustomPhrases(customContextPhrases),
+            limit: limit
+        )
+    }
+
+    static func whisperInitialPrompt(from biasPhrases: [String], maxCharacters: Int = 320) -> String? {
+        guard maxCharacters > 0 else { return nil }
+
+        let prefix = "Use these exact terms when spoken: "
+        let suffix = "."
+        var usedLength = prefix.count + suffix.count
+        var selected: [String] = []
+
+        for rawPhrase in biasPhrases {
+            let phrase = rawPhrase.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !phrase.isEmpty else { continue }
+
+            let phraseCost = phrase.count + (selected.isEmpty ? 0 : 2)
+            if usedLength + phraseCost > maxCharacters {
+                break
+            }
+
+            selected.append(phrase)
+            usedLength += phraseCost
+        }
+
+        guard !selected.isEmpty else { return nil }
+        return prefix + selected.joined(separator: ", ") + suffix
     }
 }

--- a/Sources/KeyScribe/Services/SettingsStore.swift
+++ b/Sources/KeyScribe/Services/SettingsStore.swift
@@ -25,6 +25,26 @@ enum RecognitionMode: String, CaseIterable, Identifiable {
     }
 }
 
+enum TranscriptionEngineType: String, CaseIterable, Identifiable {
+    case appleSpeech = "Apple Speech"
+    case whisperCpp = "whisper.cpp"
+
+    var id: Self { self }
+
+    var displayName: String {
+        rawValue
+    }
+
+    var helpText: String {
+        switch self {
+        case .appleSpeech:
+            return "Uses Apple Speech recognition. Supports on-device and cloud recognition modes."
+        case .whisperCpp:
+            return "Uses local whisper.cpp models downloaded to this Mac. No cloud transcription is used."
+        }
+    }
+}
+
 enum WaveformTheme: String, CaseIterable, Identifiable {
     case vibrantSpectrum = "Vibrant Spectrum"
     case professionalTech = "Professional Tech"
@@ -43,13 +63,37 @@ final class SettingsStore: ObservableObject {
     static let accessibilityTrustDidBecomeGrantedNotification = Notification.Name(
         "KeyScribe.accessibilityTrustDidBecomeGranted"
     )
+    static let noDictationSoundName = "None"
+    static let dictationStartSoundOptions = [
+        noDictationSoundName,
+        "Basso",
+        "Blow",
+        "Bottle",
+        "Frog",
+        "Funk",
+        "Glass",
+        "Hero",
+        "Ping",
+        "Pop",
+        "Purr",
+        "Sosumi",
+        "Submarine",
+        "Tink"
+    ]
+        static let defaultDictationStartSoundName = "Ping"
+        static let defaultDictationStopSoundName = "Glass"
+        static let defaultDictationProcessingSoundName = "Ping"
+        static let defaultDictationPastedSoundName = "Pop"
+        static let defaultDictationCorrectionLearnedSoundName = "Purr"
+        static let defaultDictationFeedbackVolume: Double = 0.10
 
-    private let defaults = UserDefaults.standard
-    private var isApplyingChanges = false
+        private let defaults = UserDefaults.standard
+        private var isApplyingChanges = false
 
     private enum Keys {
         static let shortcutKeyCode = "KeyScribe.shortcutKeyCode"
         static let shortcutModifiers = "KeyScribe.shortcutModifiers"
+        static let muteSystemSoundsWhileHoldingShortcut = "KeyScribe.muteSystemSoundsWhileHoldingShortcut"
         static let continuousMode = "KeyScribe.continuousMode" // legacy key kept for migration safety
         static let continuousToggleShortcutKeyCode = "KeyScribe.continuousToggleShortcutKeyCode"
         static let continuousToggleShortcutModifiers = "KeyScribe.continuousToggleShortcutModifiers"
@@ -66,6 +110,17 @@ final class SettingsStore: ObservableObject {
         static let textCleanupMode = "KeyScribe.textCleanupMode"
         static let autoPunctuation = "KeyScribe.autoPunctuation"
         static let waveformTheme = "KeyScribe.waveformTheme"
+        static let transcriptionEngine = "KeyScribe.transcriptionEngine"
+        static let selectedWhisperModelID = "KeyScribe.selectedWhisperModelID"
+        static let whisperUseCoreML = "KeyScribe.whisperUseCoreML"
+        static let adaptiveCorrectionsEnabled = "KeyScribe.adaptiveCorrectionsEnabled"
+        static let playCorrectionLearnedSound = "KeyScribe.playCorrectionLearnedSound"
+        static let dictationStartSoundName = "KeyScribe.dictationStartSoundName"
+        static let dictationStopSoundName = "KeyScribe.dictationStopSoundName"
+        static let dictationProcessingSoundName = "KeyScribe.dictationProcessingSoundName"
+        static let dictationPastedSoundName = "KeyScribe.dictationPastedSoundName"
+        static let dictationCorrectionLearnedSoundName = "KeyScribe.dictationCorrectionLearnedSoundName"
+        static let dictationFeedbackVolume = "KeyScribe.dictationFeedbackVolume"
     }
 
     private enum ContinuousToggleDefaults {
@@ -97,6 +152,12 @@ final class SettingsStore: ObservableObject {
     }
 
     @Published var continuousToggleShortcutModifiers: UInt {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var muteSystemSoundsWhileHoldingShortcut: Bool {
         didSet {
             save()
         }
@@ -179,6 +240,73 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    @Published var transcriptionEngineRawValue: String {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var selectedWhisperModelID: String {
+        didSet {
+            guard oldValue != selectedWhisperModelID else { return }
+            save()
+        }
+    }
+
+    @Published var whisperUseCoreML: Bool {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var adaptiveCorrectionsEnabled: Bool {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var playCorrectionLearnedSound: Bool {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var dictationStartSoundName: String {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var dictationStopSoundName: String {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var dictationProcessingSoundName: String {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var dictationPastedSoundName: String {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var dictationCorrectionLearnedSoundName: String {
+        didSet {
+            save()
+        }
+    }
+
+    @Published var dictationFeedbackVolume: Double {
+        didSet {
+            save()
+        }
+    }
+
     @Published var availableMicrophones: [MicrophoneOption] = []
     @Published var accessibilityTrusted: Bool = AXIsProcessTrusted()
 
@@ -229,6 +357,12 @@ final class SettingsStore: ObservableObject {
         )
         continuousToggleShortcutKeyCode = resolvedContinuousToggle.keyCode
         continuousToggleShortcutModifiers = resolvedContinuousToggle.modifiersRaw
+
+        if defaults.object(forKey: Keys.muteSystemSoundsWhileHoldingShortcut) == nil {
+            muteSystemSoundsWhileHoldingShortcut = false
+        } else {
+            muteSystemSoundsWhileHoldingShortcut = defaults.bool(forKey: Keys.muteSystemSoundsWhileHoldingShortcut)
+        }
 
         if defaults.object(forKey: Keys.autoDetectMicrophone) == nil {
             autoDetectMicrophone = true
@@ -298,6 +432,62 @@ final class SettingsStore: ObservableObject {
             waveformThemeRawValue = storedTheme
         }
 
+        let storedEngine = defaults.string(forKey: Keys.transcriptionEngine) ?? TranscriptionEngineType.appleSpeech.rawValue
+        if TranscriptionEngineType(rawValue: storedEngine) == nil {
+            transcriptionEngineRawValue = TranscriptionEngineType.appleSpeech.rawValue
+        } else {
+            transcriptionEngineRawValue = storedEngine
+        }
+
+        selectedWhisperModelID = defaults.string(forKey: Keys.selectedWhisperModelID) ?? ""
+
+        if defaults.object(forKey: Keys.whisperUseCoreML) == nil {
+            whisperUseCoreML = true
+        } else {
+            whisperUseCoreML = defaults.bool(forKey: Keys.whisperUseCoreML)
+        }
+
+        if defaults.object(forKey: Keys.adaptiveCorrectionsEnabled) == nil {
+            adaptiveCorrectionsEnabled = true
+        } else {
+            adaptiveCorrectionsEnabled = defaults.bool(forKey: Keys.adaptiveCorrectionsEnabled)
+        }
+
+        if defaults.object(forKey: Keys.playCorrectionLearnedSound) == nil {
+            playCorrectionLearnedSound = true
+        } else {
+            playCorrectionLearnedSound = defaults.bool(forKey: Keys.playCorrectionLearnedSound)
+        }
+
+        let storedStartSoundName = defaults.string(forKey: Keys.dictationStartSoundName)
+            ?? Self.defaultDictationStartSoundName
+        dictationStartSoundName = Self.dictationStartSoundOptions.contains(storedStartSoundName)
+            ? storedStartSoundName
+            : Self.defaultDictationStartSoundName
+        let storedStopSoundName = defaults.string(forKey: Keys.dictationStopSoundName)
+            ?? Self.defaultDictationStopSoundName
+        dictationStopSoundName = Self.dictationStartSoundOptions.contains(storedStopSoundName)
+            ? storedStopSoundName
+            : Self.defaultDictationStopSoundName
+        let storedProcessingSoundName = defaults.string(forKey: Keys.dictationProcessingSoundName)
+            ?? Self.defaultDictationProcessingSoundName
+        dictationProcessingSoundName = Self.dictationStartSoundOptions.contains(storedProcessingSoundName)
+            ? storedProcessingSoundName
+            : Self.defaultDictationProcessingSoundName
+        let storedPastedSoundName = defaults.string(forKey: Keys.dictationPastedSoundName)
+            ?? Self.defaultDictationPastedSoundName
+        dictationPastedSoundName = Self.dictationStartSoundOptions.contains(storedPastedSoundName)
+            ? storedPastedSoundName
+            : Self.defaultDictationPastedSoundName
+        let storedCorrectionSoundName = defaults.string(forKey: Keys.dictationCorrectionLearnedSoundName)
+            ?? Self.defaultDictationCorrectionLearnedSoundName
+        dictationCorrectionLearnedSoundName = Self.dictationStartSoundOptions.contains(storedCorrectionSoundName)
+            ? storedCorrectionSoundName
+            : Self.defaultDictationCorrectionLearnedSoundName
+        dictationFeedbackVolume = defaults.object(forKey: Keys.dictationFeedbackVolume) == nil
+            ? Self.defaultDictationFeedbackVolume
+            : min(1, max(0, defaults.double(forKey: Keys.dictationFeedbackVolume)))
+
         selectedMicrophoneUID = defaults.string(forKey: Keys.selectedMicrophoneUID) ?? ""
 
         refreshMicrophones(notifyChange: false)
@@ -355,6 +545,7 @@ final class SettingsStore: ObservableObject {
         defaults.set(Int(ShortcutValidation.filteredModifierRawValue(from: shortcutModifiers)), forKey: Keys.shortcutModifiers)
         defaults.set(Int(continuousToggleShortcutKeyCode), forKey: Keys.continuousToggleShortcutKeyCode)
         defaults.set(Int(ShortcutValidation.filteredModifierRawValue(from: continuousToggleShortcutModifiers)), forKey: Keys.continuousToggleShortcutModifiers)
+        defaults.set(muteSystemSoundsWhileHoldingShortcut, forKey: Keys.muteSystemSoundsWhileHoldingShortcut)
         defaults.set(autoDetectMicrophone, forKey: Keys.autoDetectMicrophone)
         defaults.set(selectedMicrophoneUID, forKey: Keys.selectedMicrophoneUID)
         defaults.set(copyToClipboard, forKey: Keys.copyToClipboard)
@@ -367,6 +558,17 @@ final class SettingsStore: ObservableObject {
         defaults.set(textCleanupModeRawValue, forKey: Keys.textCleanupMode)
         defaults.set(autoPunctuation, forKey: Keys.autoPunctuation)
         defaults.set(waveformThemeRawValue, forKey: Keys.waveformTheme)
+        defaults.set(transcriptionEngineRawValue, forKey: Keys.transcriptionEngine)
+        defaults.set(selectedWhisperModelID, forKey: Keys.selectedWhisperModelID)
+        defaults.set(whisperUseCoreML, forKey: Keys.whisperUseCoreML)
+        defaults.set(adaptiveCorrectionsEnabled, forKey: Keys.adaptiveCorrectionsEnabled)
+        defaults.set(playCorrectionLearnedSound, forKey: Keys.playCorrectionLearnedSound)
+        defaults.set(dictationStartSoundName, forKey: Keys.dictationStartSoundName)
+        defaults.set(dictationStopSoundName, forKey: Keys.dictationStopSoundName)
+        defaults.set(dictationProcessingSoundName, forKey: Keys.dictationProcessingSoundName)
+        defaults.set(dictationPastedSoundName, forKey: Keys.dictationPastedSoundName)
+        defaults.set(dictationCorrectionLearnedSoundName, forKey: Keys.dictationCorrectionLearnedSoundName)
+        defaults.set(dictationFeedbackVolume, forKey: Keys.dictationFeedbackVolume)
 
         guard !isApplyingChanges else { return }
         onChange?()
@@ -395,10 +597,19 @@ final class SettingsStore: ObservableObject {
         set { waveformThemeRawValue = newValue.rawValue }
     }
 
-    /// Resets all permissions, deletes UserDefaults, and removes the app bundle.
+    var transcriptionEngine: TranscriptionEngineType {
+        get { TranscriptionEngineType(rawValue: transcriptionEngineRawValue) ?? .appleSpeech }
+        set { transcriptionEngineRawValue = newValue.rawValue }
+    }
+
+    /// Resets all permissions, deletes local app data, and removes the app bundle.
     /// Requires admin privileges for tccutil and rm of /Applications bundle.
-    static func resetAndUninstall() {
+    static func resetAndUninstall(
+        deleteDownloadedModels: Bool = false,
+        deleteLearnedCorrections: Bool = false
+    ) {
         let currentBundleID = Bundle.main.bundleIdentifier ?? "com.keyscribe.KeyScribe"
+        let appName = (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) ?? "KeyScribe"
         // Include legacy IDs so old TCC rows are cleaned up during uninstall.
         let bundleIDs = Array(
             Set([
@@ -407,37 +618,71 @@ final class SettingsStore: ObservableObject {
                 "com.manikvashith.KeyScribe"
             ])
         )
-        let appPath = Bundle.main.bundlePath
+        let appRemovalPaths = Array(
+            Set([
+                Bundle.main.bundlePath,
+                "/Applications/\(appName).app",
+                "\(NSHomeDirectory())/Applications/\(appName).app"
+            ])
+        )
 
         // Build a shell script that:
         // 1. Resets TCC permissions (Accessibility, Microphone, Speech Recognition)
-        // 2. Removes UserDefaults plist
-        // 3. Removes the .app bundle from /Applications
+        // 2. Removes UserDefaults + caches + app data (optionally preserving downloaded whisper models)
+        // 3. Removes app logs and saved state
+        // 4. Removes the .app bundle from /Applications
         let resetCommands = bundleIDs.flatMap { bundleID in
             [
-                "tccutil reset Accessibility \(bundleID) 2>/dev/null || true",
-                "tccutil reset Microphone \(bundleID) 2>/dev/null || true",
-                "tccutil reset SpeechRecognition \(bundleID) 2>/dev/null || true"
+                "tccutil reset Accessibility \(shellSingleQuoted(bundleID)) 2>/dev/null || true",
+                "tccutil reset Microphone \(shellSingleQuoted(bundleID)) 2>/dev/null || true",
+                "tccutil reset SpeechRecognition \(shellSingleQuoted(bundleID)) 2>/dev/null || true"
             ]
         }.joined(separator: "; ")
 
         let prefsCleanupCommands = bundleIDs.map { bundleID in
-            "rm -f '\(NSHomeDirectory())/Library/Preferences/\(bundleID).plist'"
+            "rm -f \(shellSingleQuoted("\(NSHomeDirectory())/Library/Preferences/\(bundleID).plist"))"
         }.joined(separator: "; ")
 
         let cacheCleanupCommands = bundleIDs.map { bundleID in
-            "rm -rf '\(NSHomeDirectory())/Library/Caches/\(bundleID)'"
+            "rm -rf \(shellSingleQuoted("\(NSHomeDirectory())/Library/Caches/\(bundleID)"))"
         }.joined(separator: "; ")
+
+        let savedStateCleanupCommands = bundleIDs.map { bundleID in
+            "rm -rf \(shellSingleQuoted("\(NSHomeDirectory())/Library/Saved Application State/\(bundleID).savedState"))"
+        }.joined(separator: "; ")
+
+        let appSupportCleanupCommand: String
+        let learnedCorrectionsCleanupCommand = deleteLearnedCorrections && !deleteDownloadedModels
+            ? "rm -f \(shellSingleQuoted(AdaptiveCorrectionStore.storageFilePath()))"
+            : nil
+
+        if deleteDownloadedModels {
+            appSupportCleanupCommand = "rm -rf \(shellSingleQuoted("\(NSHomeDirectory())/Library/Application Support/KeyScribe"))"
+        } else {
+            let appSupportPath = "\(NSHomeDirectory())/Library/Application Support/KeyScribe"
+            appSupportCleanupCommand = "mkdir -p \(shellSingleQuoted(appSupportPath)) && find \(shellSingleQuoted(appSupportPath)) -mindepth 1 -maxdepth 1 ! -name 'Models' -exec rm -rf {} +"
+        }
+        let appSupportCleanupSection = [appSupportCleanupCommand, learnedCorrectionsCleanupCommand]
+            .compactMap { $0 }
+            .joined(separator: "; ")
+        let logsCleanupCommand = "rm -rf \(shellSingleQuoted("\(NSHomeDirectory())/Library/Logs/KeyScribe"))"
+        let appRemovalCommands = appRemovalPaths
+            .map { "rm -rf \(shellSingleQuoted($0))" }
+            .joined(separator: "; ")
 
         let script = """
         \(resetCommands); \
         \(prefsCleanupCommands); \
         \(cacheCleanupCommands); \
-        rm -rf '\(appPath)'
+        \(savedStateCleanupCommands); \
+        \(appSupportCleanupSection); \
+        \(logsCleanupCommand); \
+        \(appRemovalCommands)
         """
 
+        let escapedScript = appleScriptEscaped(script)
         let appleScript = """
-        do shell script "\(script)" with administrator privileges
+        do shell script "\(escapedScript)" with administrator privileges
         """
 
         var error: NSDictionary?
@@ -446,8 +691,26 @@ final class SettingsStore: ObservableObject {
             if error == nil {
                 // Successfully uninstalled — quit the app
                 NSApplication.shared.terminate(nil)
+            } else {
+                CrashReporter.logError("Uninstall failed: \(String(describing: error))")
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = "Uninstall Failed"
+                alert.informativeText = "KeyScribe could not remove the app automatically. Remove KeyScribe.app manually from Applications."
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
             }
         }
+    }
+
+    private static func shellSingleQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private static func appleScriptEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
     func hasModifier(_ modifier: NSEvent.ModifierFlags) -> Bool {

--- a/Sources/KeyScribe/Services/SpeechTranscriber.swift
+++ b/Sources/KeyScribe/Services/SpeechTranscriber.swift
@@ -1,7 +1,4 @@
-import AVFoundation
-import CoreAudio
 import Foundation
-import Speech
 
 final class SpeechTranscriber: NSObject {
     var onFinalText: ((String) -> Void)?
@@ -9,52 +6,66 @@ final class SpeechTranscriber: NSObject {
     var onAudioLevel: ((Float) -> Void)?
     var onRecordingStateChange: ((Bool) -> Void)?
 
-    private let audioEngine = AVAudioEngine()
-    private var recognitionTask: SFSpeechRecognitionTask?
-    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
-    private var recognitionEngine: SFSpeechRecognizer?
-    private var pendingFinalizeWorkItem: DispatchWorkItem?
+    private let appleTranscriber = AppleSpeechTranscriber()
+    private let whisperTranscriber = WhisperTranscriber()
 
-    private var granted = false
-    private(set) var isRecording: Bool = false
-    private var isStopping: Bool = false
-    private var committedTranscript = ""
-    private var liveTranscript = ""
-    private var bestTranscriptInCurrentSegment = ""
-    private var previousDefaultInputDevice: AudioDeviceID?
+    private var currentEngineType: TranscriptionEngineType = .appleSpeech
+    private var isRecording = false
 
-    private var autoDetectMicrophone = true
-    private var selectedMicrophoneUID = ""
-    private var enableContextualBias = true
-    private var keepTextAcrossPauses = true
-    private var recognitionMode: RecognitionMode = .localOnly
-    private var finalizeDelaySeconds: TimeInterval = 0.35
-    private var customContextPhrases: [String] = []
-    private var autoPunctuation = true
+    private struct AppleRecognitionSettings {
+        var enableContextualBias = true
+        var keepTextAcrossPauses = true
+        var recognitionMode: RecognitionMode = .localOnly
+        var autoPunctuation = true
+        var finalizeDelaySeconds: TimeInterval = 0.35
+        var customContextPhrases = ""
+        var adaptiveBiasPhrases: [String] = []
+    }
+
+    private struct WhisperSettings {
+        var selectedModelID = ""
+        var useCoreML = true
+        var finalizeDelaySeconds: TimeInterval = 0.35
+        var biasPhrases: [String] = []
+    }
+
+    private var lastAppleRecognitionSettings = AppleRecognitionSettings()
+    private var lastWhisperSettings = WhisperSettings()
 
     override init() {
-        let locale = Locale.current
-        self.recognitionEngine = SFSpeechRecognizer(locale: locale)
         super.init()
+        wireCallbacks()
     }
 
     func requestPermissions(promptIfNeeded: Bool = true) {
-        if Thread.isMainThread {
-            requestPermissionsOnMain(promptIfNeeded: promptIfNeeded)
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.requestPermissionsOnMain(promptIfNeeded: promptIfNeeded)
+        performOnMain {
+            switch self.currentEngineType {
+            case .appleSpeech:
+                self.appleTranscriber.requestPermissions(promptIfNeeded: promptIfNeeded)
+            case .whisperCpp:
+                self.whisperTranscriber.requestPermissions(promptIfNeeded: promptIfNeeded)
             }
         }
     }
 
-    func applyMicrophoneSettings(autoDetect: Bool, microphoneUID: String) {
-        if Thread.isMainThread {
-            applyMicrophoneSettingsOnMain(autoDetect: autoDetect, microphoneUID: microphoneUID)
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.applyMicrophoneSettingsOnMain(autoDetect: autoDetect, microphoneUID: microphoneUID)
+    func setTranscriptionEngine(_ engineType: TranscriptionEngineType) {
+        performOnMain {
+            guard self.currentEngineType != engineType else { return }
+
+            if self.isRecording {
+                self.activeTranscriber.stopRecording(emitFinalText: false)
+                self.isRecording = false
             }
+
+            self.currentEngineType = engineType
+            self.applyCachedSettingsToActiveEngine()
+        }
+    }
+
+    func applyMicrophoneSettings(autoDetect: Bool, microphoneUID: String) {
+        performOnMain {
+            self.appleTranscriber.applyMicrophoneSettings(autoDetect: autoDetect, microphoneUID: microphoneUID)
+            self.whisperTranscriber.applyMicrophoneSettings(autoDetect: autoDetect, microphoneUID: microphoneUID)
         }
     }
 
@@ -64,120 +75,43 @@ final class SpeechTranscriber: NSObject {
         recognitionMode: RecognitionMode,
         autoPunctuation: Bool,
         finalizeDelaySeconds: TimeInterval,
-        customContextPhrases: String
+        customContextPhrases: String,
+        adaptiveBiasPhrases: [String] = []
     ) {
-        if Thread.isMainThread {
-            applyRecognitionSettingsOnMain(
+        performOnMain {
+            self.lastAppleRecognitionSettings.enableContextualBias = enableContextualBias
+            self.lastAppleRecognitionSettings.keepTextAcrossPauses = keepTextAcrossPauses
+            self.lastAppleRecognitionSettings.recognitionMode = recognitionMode
+            self.lastAppleRecognitionSettings.autoPunctuation = autoPunctuation
+            self.lastAppleRecognitionSettings.finalizeDelaySeconds = finalizeDelaySeconds
+            self.lastAppleRecognitionSettings.customContextPhrases = customContextPhrases
+            self.lastAppleRecognitionSettings.adaptiveBiasPhrases = adaptiveBiasPhrases
+
+            self.lastWhisperSettings.finalizeDelaySeconds = finalizeDelaySeconds
+            self.lastWhisperSettings.biasPhrases = RecognitionTuning.whisperBiasPhrases(
+                customContextPhrases: customContextPhrases,
+                adaptiveBiasPhrases: adaptiveBiasPhrases
+            )
+
+            self.appleTranscriber.applyRecognitionSettings(
                 enableContextualBias: enableContextualBias,
                 keepTextAcrossPauses: keepTextAcrossPauses,
                 recognitionMode: recognitionMode,
                 autoPunctuation: autoPunctuation,
                 finalizeDelaySeconds: finalizeDelaySeconds,
-                customContextPhrases: customContextPhrases
+                customContextPhrases: customContextPhrases,
+                adaptiveBiasPhrases: adaptiveBiasPhrases
             )
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.applyRecognitionSettingsOnMain(
-                    enableContextualBias: enableContextualBias,
-                    keepTextAcrossPauses: keepTextAcrossPauses,
-                    recognitionMode: recognitionMode,
-                    autoPunctuation: autoPunctuation,
-                    finalizeDelaySeconds: finalizeDelaySeconds,
-                    customContextPhrases: customContextPhrases
-                )
-            }
+            self.whisperTranscriber.applyBiasPhrases(self.lastWhisperSettings.biasPhrases)
+            self.whisperTranscriber.applyFinalizeDelaySeconds(finalizeDelaySeconds)
         }
     }
 
-    private func requestPermissionsOnMain(promptIfNeeded: Bool) {
-        switch SFSpeechRecognizer.authorizationStatus() {
-        case .authorized:
-            requestAudioPermissionIfNeededOnMain(promptIfNeeded: promptIfNeeded)
-
-        case .notDetermined:
-            guard promptIfNeeded else {
-                granted = false
-                return
-            }
-
-            SFSpeechRecognizer.requestAuthorization { [weak self] status in
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    switch status {
-                    case .authorized:
-                        self.requestAudioPermissionIfNeededOnMain(promptIfNeeded: promptIfNeeded)
-                    default:
-                        self.granted = false
-                        self.update("Speech permission not granted")
-                    }
-                }
-            }
-
-        default:
-            granted = false
-            update("Speech permission not granted")
-        }
-    }
-
-    private func applyMicrophoneSettingsOnMain(autoDetect: Bool, microphoneUID: String) {
-        autoDetectMicrophone = autoDetect
-        selectedMicrophoneUID = microphoneUID
-    }
-
-    private func applyRecognitionSettingsOnMain(
-        enableContextualBias: Bool,
-        keepTextAcrossPauses: Bool,
-        recognitionMode: RecognitionMode,
-        autoPunctuation: Bool,
-        finalizeDelaySeconds: TimeInterval,
-        customContextPhrases: String
-    ) {
-        self.enableContextualBias = enableContextualBias
-        self.keepTextAcrossPauses = keepTextAcrossPauses
-        self.recognitionMode = recognitionMode
-        self.autoPunctuation = autoPunctuation
-        self.finalizeDelaySeconds = RecognitionTuning.clampedFinalizeDelay(finalizeDelaySeconds)
-        self.customContextPhrases = RecognitionTuning.parseCustomPhrases(customContextPhrases)
-    }
-
-    private func requestAudioPermissionIfNeededOnMain(promptIfNeeded: Bool) {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
-            granted = true
-            update("Permissions ready")
-
-        case .notDetermined:
-            guard promptIfNeeded else {
-                granted = false
-                return
-            }
-
-            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    if granted {
-                        self.granted = true
-                        self.update("Permissions ready")
-                    } else {
-                        self.granted = false
-                        self.update("Microphone permission not granted")
-                    }
-                }
-            }
-
-        default:
-            granted = false
-            update("Microphone permission not granted")
-        }
-    }
-
-    private func update(_ message: String) {
-        if Thread.isMainThread {
-            onStatusUpdate?(message)
-        } else {
-            DispatchQueue.main.async {
-                self.onStatusUpdate?(message)
-            }
+    func applyWhisperSettings(selectedModelID: String, useCoreML: Bool) {
+        performOnMain {
+            self.lastWhisperSettings.selectedModelID = selectedModelID
+            self.lastWhisperSettings.useCoreML = useCoreML
+            self.whisperTranscriber.applyWhisperSettings(selectedModelID: selectedModelID, useCoreML: useCoreML)
         }
     }
 
@@ -193,323 +127,125 @@ final class SpeechTranscriber: NSObject {
     }
 
     func stopRecording(emitFinalText: Bool = true) {
-        if Thread.isMainThread {
-            stopRecordingOnMain(emitFinalText: emitFinalText)
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.stopRecordingOnMain(emitFinalText: emitFinalText)
-            }
+        performOnMain {
+            self.activeTranscriber.stopRecording(emitFinalText: emitFinalText)
         }
     }
 
     @discardableResult
     private func startRecordingOnMain() -> Bool {
-        guard granted else {
-            // Re-check/request permissions on demand so first-run users are not stuck.
-            requestPermissionsOnMain(promptIfNeeded: true)
-            update("Permissions missing")
-            return false
-        }
-
-        guard !isRecording && !isStopping else { return false }
-        guard let recognitionEngine else {
-            update("No speech recognizer for locale")
-            return false
-        }
-        guard recognitionEngine.isAvailable else {
-            update("Speech recognizer unavailable")
-            return false
-        }
-
-        applyMicSelection()
-
-        pendingFinalizeWorkItem?.cancel()
-        pendingFinalizeWorkItem = nil
-        isStopping = false
-
-        committedTranscript = ""
-        liveTranscript = ""
-        bestTranscriptInCurrentSegment = ""
-        isRecording = true
-        onRecordingStateChange?(true)
-
-        guard startRecognitionTask() else {
+        let started = activeTranscriber.startRecording()
+        if !started {
             isRecording = false
-            onRecordingStateChange?(false)
-            return false
         }
+        return started
+    }
 
-        let inputNode = audioEngine.inputNode
-        let format = inputNode.outputFormat(forBus: 0)
-        let activeRecognitionRequest = recognitionRequest
-
-        inputNode.removeTap(onBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-            activeRecognitionRequest?.append(buffer)
-            guard let self else { return }
-
-            let audioLevel = self.normalizedAudioLevel(from: buffer)
-            DispatchQueue.main.async {
-                self.onAudioLevel?(audioLevel)
-            }
-        }
-
-        do {
-            audioEngine.prepare()
-            try audioEngine.start()
-            update("Listening…")
-            return true
-        } catch {
-            update("Audio setup failed: \(error.localizedDescription)")
-            stopRecordingOnMain(emitFinalText: false)
-            return false
+    private var activeTranscriber: EngineTranscriber {
+        switch currentEngineType {
+        case .appleSpeech:
+            return .apple(appleTranscriber)
+        case .whisperCpp:
+            return .whisper(whisperTranscriber)
         }
     }
 
-    private func stopRecordingOnMain(emitFinalText: Bool = true) {
-        guard isRecording || isStopping else {
-            onAudioLevel?(0)
-            onRecordingStateChange?(false)
-            return
-        }
+    private func applyCachedSettingsToActiveEngine() {
+        switch currentEngineType {
+        case .appleSpeech:
+            appleTranscriber.applyRecognitionSettings(
+                enableContextualBias: lastAppleRecognitionSettings.enableContextualBias,
+                keepTextAcrossPauses: lastAppleRecognitionSettings.keepTextAcrossPauses,
+                recognitionMode: lastAppleRecognitionSettings.recognitionMode,
+                autoPunctuation: lastAppleRecognitionSettings.autoPunctuation,
+                finalizeDelaySeconds: lastAppleRecognitionSettings.finalizeDelaySeconds,
+                customContextPhrases: lastAppleRecognitionSettings.customContextPhrases,
+                adaptiveBiasPhrases: lastAppleRecognitionSettings.adaptiveBiasPhrases
+            )
 
-        if isRecording {
-            isRecording = false
-            isStopping = true
-            onRecordingStateChange?(false)
-
-            recognitionRequest?.endAudio()
-
-            audioEngine.inputNode.removeTap(onBus: 0)
-            audioEngine.stop()
-            onAudioLevel?(0)
-        }
-
-        pendingFinalizeWorkItem?.cancel()
-        let workItem = DispatchWorkItem { [weak self] in
-            self?.finalizeStop(emitFinalText: emitFinalText)
-        }
-        pendingFinalizeWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + finalizeDelaySeconds, execute: workItem)
-    }
-
-    private func finalizeStop(emitFinalText: Bool) {
-        pendingFinalizeWorkItem = nil
-        recognitionTask?.cancel()
-        recognitionTask = nil
-        recognitionRequest = nil
-        restoreMicSelection()
-
-        let text = mergedTranscript().trimmingCharacters(in: .whitespacesAndNewlines)
-        committedTranscript = ""
-        liveTranscript = ""
-        bestTranscriptInCurrentSegment = ""
-        isStopping = false
-
-        update("Ready")
-
-        if emitFinalText && !text.isEmpty {
-            onFinalText?(text)
+        case .whisperCpp:
+            whisperTranscriber.applyWhisperSettings(
+                selectedModelID: lastWhisperSettings.selectedModelID,
+                useCoreML: lastWhisperSettings.useCoreML
+            )
+            whisperTranscriber.applyBiasPhrases(lastWhisperSettings.biasPhrases)
+            whisperTranscriber.applyFinalizeDelaySeconds(lastWhisperSettings.finalizeDelaySeconds)
         }
     }
 
-    private func startRecognitionTask() -> Bool {
-        guard let recognitionEngine else {
-            update("No speech recognizer for locale")
-            return false
+    private func wireCallbacks() {
+        appleTranscriber.onFinalText = { [weak self] text in
+            guard let self, self.currentEngineType == .appleSpeech else { return }
+            self.onFinalText?(text)
         }
 
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        if #available(macOS 13, *) {
-            switch recognitionMode {
-            case .localOnly:
-                request.requiresOnDeviceRecognition = true
-            case .cloudOnly, .automatic:
-                request.requiresOnDeviceRecognition = false
-            }
-            request.addsPunctuation = autoPunctuation
-        }
-        request.taskHint = .dictation
-        if enableContextualBias {
-            let defaults = [
-                "KeyScribe",
-                "OpenClaw",
-                "dictation",
-                "transcription",
-                "macOS"
-            ]
-            request.contextualStrings = RecognitionTuning.contextualHints(defaults: defaults, custom: customContextPhrases, limit: 80)
+        appleTranscriber.onStatusUpdate = { [weak self] message in
+            guard let self, self.currentEngineType == .appleSpeech else { return }
+            self.onStatusUpdate?(message)
         }
 
-        bestTranscriptInCurrentSegment = ""
-
-        recognitionRequest = request
-        recognitionTask = recognitionEngine.recognitionTask(with: request) { [weak self] result, error in
-            DispatchQueue.main.async { [weak self] in
-                self?.handleRecognitionCallback(result: result, error: error)
-            }
+        appleTranscriber.onAudioLevel = { [weak self] level in
+            guard let self, self.currentEngineType == .appleSpeech else { return }
+            self.onAudioLevel?(level)
         }
 
-        return true
-    }
-
-    private func handleRecognitionCallback(result: SFSpeechRecognitionResult?, error: Error?) {
-        guard isRecording || isStopping else { return }
-
-        if let error {
-            let nsError = error as NSError
-            // Ignore expected cancellation noise when we stop/restart the task intentionally.
-            if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 216 {
-                return
-            }
-            if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                return
-            }
-
-            update("Error: \(error.localizedDescription)")
-            stopRecordingOnMain(emitFinalText: false)
-            return
+        appleTranscriber.onRecordingStateChange = { [weak self] recording in
+            guard let self, self.currentEngineType == .appleSpeech else { return }
+            self.isRecording = recording
+            self.onRecordingStateChange?(recording)
         }
 
-        guard let result else { return }
-        let candidate = result.bestTranscription.formattedString
-        liveTranscript = candidate
-
-        if keepTextAcrossPauses {
-            updateBestTranscriptForCurrentSegment(with: candidate)
+        whisperTranscriber.onFinalText = { [weak self] text in
+            guard let self, self.currentEngineType == .whisperCpp else { return }
+            self.onFinalText?(text)
         }
 
-        if result.isFinal {
-            if keepTextAcrossPauses {
-                commitBestSegmentTranscript()
-            } else {
-                commitLiveTranscript()
-            }
+        whisperTranscriber.onStatusUpdate = { [weak self] message in
+            guard let self, self.currentEngineType == .whisperCpp else { return }
+            self.onStatusUpdate?(message)
+        }
 
-            if isRecording {
-                _ = startRecognitionTask()
-            }
+        whisperTranscriber.onAudioLevel = { [weak self] level in
+            guard let self, self.currentEngineType == .whisperCpp else { return }
+            self.onAudioLevel?(level)
+        }
+
+        whisperTranscriber.onRecordingStateChange = { [weak self] recording in
+            guard let self, self.currentEngineType == .whisperCpp else { return }
+            self.isRecording = recording
+            self.onRecordingStateChange?(recording)
         }
     }
 
-    private func updateBestTranscriptForCurrentSegment(with candidate: String) {
-        let candidateText = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
-        let existingText = bestTranscriptInCurrentSegment.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !candidateText.isEmpty else { return }
-
-        if RecognitionTuning.scoreTranscript(candidateText) >= RecognitionTuning.scoreTranscript(existingText) {
-            bestTranscriptInCurrentSegment = candidateText
-        }
-    }
-
-    private func commitBestSegmentTranscript() {
-        let fallback = liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        let best = bestTranscriptInCurrentSegment.trimmingCharacters(in: .whitespacesAndNewlines)
-        let chunk = RecognitionTuning.chooseBetterTranscript(primary: best, fallback: fallback)
-
-        guard !chunk.isEmpty else {
-            liveTranscript = ""
-            bestTranscriptInCurrentSegment = ""
-            return
-        }
-
-        if committedTranscript.isEmpty {
-            committedTranscript = chunk
+    private func performOnMain(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
         } else {
-            committedTranscript += " " + chunk
-        }
-
-        liveTranscript = ""
-        bestTranscriptInCurrentSegment = ""
-    }
-
-    private func commitLiveTranscript() {
-        let chunk = liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !chunk.isEmpty else { return }
-
-        if committedTranscript.isEmpty {
-            committedTranscript = chunk
-        } else {
-            committedTranscript += " " + chunk
-        }
-        liveTranscript = ""
-        bestTranscriptInCurrentSegment = ""
-    }
-
-    private func mergedTranscript() -> String {
-        let current = liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        let best = bestTranscriptInCurrentSegment.trimmingCharacters(in: .whitespacesAndNewlines)
-        let tail = RecognitionTuning.chooseBetterTranscript(primary: best, fallback: current)
-
-        if committedTranscript.isEmpty { return tail }
-        if tail.isEmpty { return committedTranscript }
-        return committedTranscript + " " + tail
-    }
-
-    private func applyMicSelection() {
-        guard !autoDetectMicrophone else {
-            previousDefaultInputDevice = nil
-            return
-        }
-
-        guard !selectedMicrophoneUID.isEmpty else {
-            previousDefaultInputDevice = nil
-            return
-        }
-
-        guard let selectedDeviceID = MicrophoneManager.deviceID(forUID: selectedMicrophoneUID) else {
-            update("Selected microphone no longer available")
-            previousDefaultInputDevice = nil
-            return
-        }
-
-        guard let currentDefault = MicrophoneManager.defaultInputDeviceID() else {
-            update("Unable to read default microphone")
-            previousDefaultInputDevice = nil
-            return
-        }
-
-        if currentDefault == selectedDeviceID {
-            previousDefaultInputDevice = nil
-            return
-        }
-
-        let changed = MicrophoneManager.setDefaultInput(deviceID: selectedDeviceID)
-        if changed {
-            previousDefaultInputDevice = currentDefault
-        } else {
-            update("Could not switch microphone")
-            previousDefaultInputDevice = nil
+            DispatchQueue.main.async(execute: block)
         }
     }
 
-    private func restoreMicSelection() {
-        guard let previous = previousDefaultInputDevice else { return }
-        _ = MicrophoneManager.setDefaultInput(deviceID: previous)
-        previousDefaultInputDevice = nil
-    }
+    private enum EngineTranscriber {
+        case apple(AppleSpeechTranscriber)
+        case whisper(WhisperTranscriber)
 
-    private func normalizedAudioLevel(from buffer: AVAudioPCMBuffer) -> Float {
-        guard let channelData = buffer.floatChannelData else {
-            return 0
+        @discardableResult
+        func startRecording() -> Bool {
+            switch self {
+            case let .apple(transcriber):
+                return transcriber.startRecording()
+            case let .whisper(transcriber):
+                return transcriber.startRecording()
+            }
         }
 
-        let channelSamples = channelData.pointee
-        let frameCount = Int(buffer.frameLength)
-        guard frameCount > 0 else { return 0 }
-
-        var sum: Float = 0
-        for i in 0..<frameCount {
-            let sample = channelSamples[i]
-            sum += sample * sample
+        func stopRecording(emitFinalText: Bool) {
+            switch self {
+            case let .apple(transcriber):
+                transcriber.stopRecording(emitFinalText: emitFinalText)
+            case let .whisper(transcriber):
+                transcriber.stopRecording(emitFinalText: emitFinalText)
+            }
         }
-
-        let meanSquare = sum / Float(frameCount)
-        let rms = sqrtf(max(meanSquare, 1e-12))
-        let db = 20 * log10f(rms)
-        let normalized = (db + 70) / 70
-        return max(0, min(1, normalized))
     }
 }

--- a/Sources/KeyScribe/Services/WaveformHUD.swift
+++ b/Sources/KeyScribe/Services/WaveformHUD.swift
@@ -2,8 +2,11 @@ import AppKit
 import SwiftUI
 
 private enum HUDLayout {
-    static let width: CGFloat = 100
-    static let height: CGFloat = 34
+    static let waveformWidth: CGFloat = 100
+    static let waveformHeight: CGFloat = 34
+    static let toastWidth: CGFloat = 360
+    static let toastHeight: CGFloat = 38
+    static let toastVerticalGap: CGFloat = 12
     /// Fixed offset from the bottom of the screen so the HUD always sits
     /// above the Dock region, even on screens that don't host the Dock.
     static let dockReserve: CGFloat = 80
@@ -11,32 +14,60 @@ private enum HUDLayout {
 
 @MainActor
 final class WaveformHUDManager {
-    private var panel: NSPanel?
-    private let model = WaveformModel()
+    private var waveformPanel: NSPanel?
+    private var toastPanel: NSPanel?
+    private let waveformModel = WaveformModel()
+    private let toastModel = HUDToastModel()
+    private var toastHideWorkItem: DispatchWorkItem?
 
     func show() {
-        if panel == nil {
-            createPanel()
+        if waveformPanel == nil {
+            createWaveformPanel()
         }
-        guard let panel else { return }
-        model.reset()
-        model.startAnimating()
-        repositionAtBottom()
-        panel.orderFrontRegardless()
+        guard let waveformPanel else { return }
+        waveformModel.reset()
+        waveformModel.startAnimating()
+        repositionWaveformPanel()
+        waveformPanel.orderFrontRegardless()
     }
 
     func hide() {
-        model.stopAnimating()
-        model.reset()
-        panel?.orderOut(nil)
+        waveformModel.stopAnimating()
+        waveformModel.reset()
+        waveformPanel?.orderOut(nil)
     }
 
     func updateLevel(_ level: Float) {
-        model.updateLevel(level)
+        waveformModel.updateLevel(level)
     }
 
-    private func createPanel() {
-        let frame = NSRect(x: 0, y: 0, width: HUDLayout.width, height: HUDLayout.height)
+    func flashEvent(message: String, symbolName: String = "checkmark.circle.fill", duration: TimeInterval = 1.4) {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        if toastPanel == nil {
+            createToastPanel()
+        }
+
+        guard let toastPanel else { return }
+
+        toastHideWorkItem?.cancel()
+        toastModel.symbolName = symbolName
+        toastModel.message = trimmed
+        repositionToastPanel()
+        toastPanel.orderFrontRegardless()
+
+        let hideWorkItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                self?.toastPanel?.orderOut(nil)
+            }
+        }
+        toastHideWorkItem = hideWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: hideWorkItem)
+    }
+
+    private func createWaveformPanel() {
+        let frame = NSRect(x: 0, y: 0, width: HUDLayout.waveformWidth, height: HUDLayout.waveformHeight)
         let panel = NSPanel(
             contentRect: frame,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -53,21 +84,55 @@ final class WaveformHUDManager {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.ignoresMouseEvents = true
 
-        let hosting = NSHostingController(rootView: WaveformPanelView(model: model))
+        let hosting = NSHostingController(rootView: WaveformPanelView(model: waveformModel))
         hosting.view.frame = frame
         panel.contentViewController = hosting
-        self.panel = panel
+        self.waveformPanel = panel
     }
 
-    private func repositionAtBottom() {
-        guard let panel else { return }
+    private func createToastPanel() {
+        let frame = NSRect(x: 0, y: 0, width: HUDLayout.toastWidth, height: HUDLayout.toastHeight)
+        let panel = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.isFloatingPanel = true
+        panel.level = .statusBar
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.ignoresMouseEvents = true
+
+        let hosting = NSHostingController(rootView: HUDToastView(model: toastModel))
+        hosting.view.frame = frame
+        panel.contentViewController = hosting
+        toastPanel = panel
+    }
+
+    private func repositionWaveformPanel() {
+        guard let waveformPanel else { return }
         let screen = NSScreen.main ?? NSScreen.screens.first
         guard let screen else { return }
 
-        let x = screen.frame.midX - (panel.frame.width * 0.5)
+        let x = screen.frame.midX - (waveformPanel.frame.width * 0.5)
         let y = screen.frame.minY + HUDLayout.dockReserve
 
-        panel.setFrameOrigin(NSPoint(x: x, y: y))
+        waveformPanel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func repositionToastPanel() {
+        guard let toastPanel else { return }
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let x = screen.frame.midX - (toastPanel.frame.width * 0.5)
+        let y = screen.frame.minY + HUDLayout.dockReserve + HUDLayout.waveformHeight + HUDLayout.toastVerticalGap
+        toastPanel.setFrameOrigin(NSPoint(x: x, y: y))
     }
 }
 
@@ -149,7 +214,50 @@ struct WaveformPanelView: View {
                     .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
             }
         )
-        .frame(width: HUDLayout.width, height: HUDLayout.height, alignment: .center)
+        .frame(width: HUDLayout.waveformWidth, height: HUDLayout.waveformHeight, alignment: .center)
+        .shadow(color: .black.opacity(0.25), radius: 8, x: 0, y: 2)
+    }
+}
+
+@MainActor
+final class HUDToastModel: ObservableObject {
+    @Published var symbolName: String = "checkmark.circle.fill"
+    @Published var message: String = ""
+}
+
+struct HUDToastView: View {
+    @ObservedObject var model: HUDToastModel
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(Color.red)
+                .frame(width: 7, height: 7)
+
+            Image(systemName: model.symbolName)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.green)
+
+            Text(model.message)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            ZStack {
+                Capsule()
+                    .fill(.ultraThinMaterial)
+                Capsule()
+                    .fill(Color.white.opacity(0.06))
+                Capsule()
+                    .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+            }
+        )
+        .frame(width: HUDLayout.toastWidth, height: HUDLayout.toastHeight, alignment: .center)
         .shadow(color: .black.opacity(0.25), radius: 8, x: 0, y: 2)
     }
 }

--- a/Sources/KeyScribe/Services/WhisperModelCatalog.swift
+++ b/Sources/KeyScribe/Services/WhisperModelCatalog.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+struct WhisperModelCatalog {
+    struct Model: Identifiable, Hashable {
+        let id: String
+        let displayName: String
+        let useCaseDescription: String
+        let diskSizeText: String
+        let memoryFootprintText: String
+        let ggmlDownloadURL: URL
+        let ggmlSHA1: String?
+        let coreMLDownloadURL: URL?
+        let family: String
+        let isEnglishOnly: Bool
+        let isQuantized: Bool
+        let isDiarization: Bool
+
+        var ggmlFilename: String {
+            "ggml-\(id).bin"
+        }
+
+        var coreMLDirectoryName: String {
+            "ggml-\(id)-encoder.mlmodelc"
+        }
+    }
+
+    static let modelIDs: [String] = [
+        "tiny",
+        "tiny.en",
+        "tiny-q5_1",
+        "tiny.en-q5_1",
+        "tiny-q8_0",
+        "base",
+        "base.en",
+        "base-q5_1",
+        "base.en-q5_1",
+        "base-q8_0",
+        "small",
+        "small.en",
+        "small.en-tdrz",
+        "small-q5_1",
+        "small.en-q5_1",
+        "small-q8_0",
+        "medium",
+        "medium.en",
+        "medium-q5_0",
+        "medium.en-q5_0",
+        "medium-q8_0",
+        "large-v1",
+        "large-v2",
+        "large-v2-q5_0",
+        "large-v2-q8_0",
+        "large-v3",
+        "large-v3-q5_0",
+        "large-v3-turbo",
+        "large-v3-turbo-q5_0",
+        "large-v3-turbo-q8_0"
+    ]
+
+    static let curatedModels: [Model] = modelIDs.map(makeModel)
+
+    static func model(withID id: String) -> Model? {
+        curatedModels.first(where: { $0.id == id })
+    }
+
+    private static func makeModel(id: String) -> Model {
+        let family = familyForModelID(id)
+        let isQuantized = id.contains("-q")
+        let isEnglishOnly = id.contains(".en")
+        let isDiarization = id.contains("tdrz")
+        let isTurbo = id.contains("turbo")
+
+        let baseRepo = isDiarization
+            ? "https://huggingface.co/akashmjn/tinydiarize-whisper.cpp/resolve/main"
+            : "https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
+
+        let ggmlURL = URL(string: "\(baseRepo)/ggml-\(id).bin")!
+        let coreMLURL: URL?
+        if isQuantized || isDiarization {
+            coreMLURL = nil
+        } else {
+            coreMLURL = URL(string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-\(id)-encoder.mlmodelc.zip")
+        }
+
+        return Model(
+            id: id,
+            displayName: id,
+            useCaseDescription: useCaseDescription(
+                family: family,
+                isQuantized: isQuantized,
+                isEnglishOnly: isEnglishOnly,
+                isDiarization: isDiarization,
+                isTurbo: isTurbo
+            ),
+            diskSizeText: diskSizeText(family: family, isQuantized: isQuantized, isTurbo: isTurbo),
+            memoryFootprintText: memoryText(family: family, isQuantized: isQuantized, isTurbo: isTurbo),
+            ggmlDownloadURL: ggmlURL,
+            ggmlSHA1: sha1ByModelID[id],
+            coreMLDownloadURL: coreMLURL,
+            family: family,
+            isEnglishOnly: isEnglishOnly,
+            isQuantized: isQuantized,
+            isDiarization: isDiarization
+        )
+    }
+
+    private static func familyForModelID(_ id: String) -> String {
+        if id.hasPrefix("large") {
+            return "large"
+        }
+
+        if let firstPart = id.split(whereSeparator: { $0 == "." || $0 == "-" }).first {
+            return String(firstPart)
+        }
+
+        return id
+    }
+
+    private static func useCaseDescription(
+        family: String,
+        isQuantized: Bool,
+        isEnglishOnly: Bool,
+        isDiarization: Bool,
+        isTurbo: Bool
+    ) -> String {
+        if isDiarization {
+            return "Speaker-aware tiny diarization model. Best when you need simple speaker turns."
+        }
+
+        var base: String
+        switch family {
+        case "tiny":
+            base = "Fastest and lightest. Best for quick notes and lowest resource use."
+        case "base":
+            base = "Balanced speed and accuracy. Good default for daily dictation."
+        case "small":
+            base = "Higher accuracy with moderate CPU and memory cost."
+        case "medium":
+            base = "Strong accuracy for harder audio, accents, and noisy environments."
+        case "large":
+            base = isTurbo
+                ? "Near-large accuracy with better speed than standard large models."
+                : "Highest accuracy, but heaviest on memory/CPU and slowest to run."
+        default:
+            base = "General-purpose whisper.cpp model."
+        }
+
+        if isQuantized {
+            base += " Quantized variant: smaller download and memory footprint with some accuracy tradeoff."
+        }
+
+        if isEnglishOnly {
+            base += " English-only model."
+        } else {
+            base += " Multilingual model."
+        }
+
+        return base
+    }
+
+    private static func diskSizeText(family: String, isQuantized: Bool, isTurbo: Bool) -> String {
+        if isQuantized {
+            switch family {
+            case "tiny": return "~31–42 MiB"
+            case "base": return "~57–81 MiB"
+            case "small": return "~181–268 MiB"
+            case "medium": return "~590–860 MiB"
+            case "large": return isTurbo ? "~640 MiB–1.1 GiB" : "~1.1–1.8 GiB"
+            default: return "Quantized size"
+            }
+        }
+
+        switch family {
+        case "tiny":
+            return "75 MiB"
+        case "base":
+            return "142 MiB"
+        case "small":
+            return "466 MiB"
+        case "medium":
+            return "1.5 GiB"
+        case "large":
+            return isTurbo ? "1.6 GiB" : "2.9 GiB"
+        default:
+            return "Model size"
+        }
+    }
+
+    private static func memoryText(family: String, isQuantized: Bool, isTurbo: Bool) -> String {
+        if isQuantized {
+            switch family {
+            case "tiny": return "~180–240 MB"
+            case "base": return "~240–320 MB"
+            case "small": return "~520–700 MB"
+            case "medium": return "~1.1–1.6 GB"
+            case "large": return isTurbo ? "~1.6–2.4 GB" : "~2.1–3.2 GB"
+            default: return "Lower than full"
+            }
+        }
+
+        switch family {
+        case "tiny":
+            return "~273 MB"
+        case "base":
+            return "~388 MB"
+        case "small":
+            return "~852 MB"
+        case "medium":
+            return "~2.1 GB"
+        case "large":
+            return isTurbo ? "~2.3 GB" : "~3.9 GB"
+        default:
+            return "Model memory"
+        }
+    }
+
+    private static let sha1ByModelID: [String: String] = [
+        "tiny.en": "c78c86eb1a8faa21b369bcd33207cc90d64ae9df",
+        "base.en": "137c40403d78fd54d454da0f9bd998f78703390c",
+        "small.en": "db8a495a91d927739e50b3fc1cc4c6b8f6c2d022"
+    ]
+}

--- a/Sources/KeyScribe/Services/WhisperModelManager.swift
+++ b/Sources/KeyScribe/Services/WhisperModelManager.swift
@@ -1,0 +1,479 @@
+import CryptoKit
+import Foundation
+
+final class WhisperModelManager: NSObject, ObservableObject {
+    static let shared = WhisperModelManager()
+
+    enum InstallState: Equatable {
+        case notInstalled
+        case downloading(progress: Double)
+        case installing
+        case installed
+        case failed(message: String)
+    }
+
+    @Published private(set) var installStateByModelID: [String: InstallState] = [:]
+
+    private enum DownloadAssetKind {
+        case ggml
+        case coreMLZip
+    }
+
+    private struct DownloadTaskInfo {
+        let modelID: String
+        let kind: DownloadAssetKind
+    }
+
+    private struct PendingInstall {
+        let model: WhisperModelCatalog.Model
+        let includeCoreML: Bool
+        var ggmlTempURL: URL?
+        var coreMLZipTempURL: URL?
+    }
+
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.default
+        // Large models can take a while on slower or unstable networks.
+        config.waitsForConnectivity = true
+        config.timeoutIntervalForRequest = 10 * 60
+        config.timeoutIntervalForResource = 6 * 60 * 60
+        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }()
+
+    private let maxRetryCount = 3
+    private var pendingInstallByModelID: [String: PendingInstall] = [:]
+    private var taskInfoByTaskID: [Int: DownloadTaskInfo] = [:]
+    private var retryCountByTaskKey: [String: Int] = [:]
+
+    private override init() {
+        super.init()
+        for model in WhisperModelCatalog.curatedModels {
+            installStateByModelID[model.id] = .notInstalled
+        }
+        refreshInstallStates()
+    }
+
+    func refreshInstallStates() {
+        for model in WhisperModelCatalog.curatedModels {
+            if case .downloading = installStateByModelID[model.id] {
+                continue
+            }
+            if case .installing = installStateByModelID[model.id] {
+                continue
+            }
+
+            installStateByModelID[model.id] = hasInstalledModel(id: model.id)
+                ? .installed
+                : .notInstalled
+        }
+    }
+
+    func hasInstalledModel(id: String) -> Bool {
+        guard !id.isEmpty else { return false }
+        return FileManager.default.fileExists(atPath: modelFileURL(for: id).path)
+    }
+
+    func installedModelURL(for id: String) -> URL? {
+        guard hasInstalledModel(id: id) else { return nil }
+        return modelFileURL(for: id)
+    }
+
+    func installedCoreMLDirectoryURL(for id: String) -> URL? {
+        let url = coreMLDirectoryURL(for: id)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    func hasAnyInstalledModel() -> Bool {
+        WhisperModelCatalog.curatedModels.contains(where: { hasInstalledModel(id: $0.id) })
+    }
+
+    func installModel(modelID: String, includeCoreML: Bool) {
+        guard let model = WhisperModelCatalog.model(withID: modelID) else {
+            return
+        }
+
+        cancelDownload(modelID: modelID)
+
+        pendingInstallByModelID[modelID] = PendingInstall(
+            model: model,
+            includeCoreML: includeCoreML,
+            ggmlTempURL: nil,
+            coreMLZipTempURL: nil
+        )
+        installStateByModelID[modelID] = .downloading(progress: 0)
+        startDownload(for: modelID, kind: .ggml)
+    }
+
+    func cancelDownload(modelID: String) {
+        let taskIDs = taskInfoByTaskID.compactMap { entry -> Int? in
+            entry.value.modelID == modelID ? entry.key : nil
+        }
+        for taskID in taskIDs {
+            taskInfoByTaskID.removeValue(forKey: taskID)
+        }
+
+        session.getAllTasks { tasks in
+            tasks.filter { taskIDs.contains($0.taskIdentifier) }.forEach { $0.cancel() }
+        }
+
+        pendingInstallByModelID.removeValue(forKey: modelID)
+        retryCountByTaskKey = retryCountByTaskKey.filter { !$0.key.hasPrefix("\(modelID)|") }
+        installStateByModelID[modelID] = hasInstalledModel(id: modelID) ? .installed : .notInstalled
+    }
+
+    func deleteModel(modelID: String) {
+        cancelDownload(modelID: modelID)
+        let fm = FileManager.default
+
+        let modelURL = modelFileURL(for: modelID)
+        if fm.fileExists(atPath: modelURL.path) {
+            try? fm.removeItem(at: modelURL)
+        }
+
+        let coreMLURL = coreMLDirectoryURL(for: modelID)
+        if fm.fileExists(atPath: coreMLURL.path) {
+            try? fm.removeItem(at: coreMLURL)
+        }
+
+        installStateByModelID[modelID] = .notInstalled
+    }
+
+    private func startDownload(for modelID: String, kind: DownloadAssetKind) {
+        guard let pending = pendingInstallByModelID[modelID] else { return }
+
+        let sourceURL: URL
+        switch kind {
+        case .ggml:
+            sourceURL = pending.model.ggmlDownloadURL
+        case .coreMLZip:
+            guard let coreMLURL = pending.model.coreMLDownloadURL else {
+                finalizeInstall(for: modelID)
+                return
+            }
+            sourceURL = coreMLURL
+        }
+
+        var request = URLRequest(url: sourceURL)
+        request.timeoutInterval = 10 * 60
+        request.setValue("KeyScribe/1.0", forHTTPHeaderField: "User-Agent")
+
+        let task = session.downloadTask(with: request)
+        taskInfoByTaskID[task.taskIdentifier] = DownloadTaskInfo(modelID: modelID, kind: kind)
+        task.resume()
+    }
+
+    private func handleDownloadFinished(taskIdentifier: Int, temporaryLocation: URL) {
+        guard let taskInfo = taskInfoByTaskID[taskIdentifier],
+              var pending = pendingInstallByModelID[taskInfo.modelID] else {
+            return
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("keyscribe-whisper-\(UUID().uuidString)")
+
+        do {
+            try FileManager.default.moveItem(at: temporaryLocation, to: tempURL)
+        } catch {
+            installStateByModelID[taskInfo.modelID] = .failed(message: "Failed to stage download: \(error.localizedDescription)")
+            pendingInstallByModelID.removeValue(forKey: taskInfo.modelID)
+            return
+        }
+
+        switch taskInfo.kind {
+        case .ggml:
+            retryCountByTaskKey[taskKey(modelID: taskInfo.modelID, kind: .ggml)] = 0
+            pending.ggmlTempURL = tempURL
+            pendingInstallByModelID[taskInfo.modelID] = pending
+
+            if pending.includeCoreML, pending.model.coreMLDownloadURL != nil {
+                startDownload(for: taskInfo.modelID, kind: .coreMLZip)
+            } else {
+                finalizeInstall(for: taskInfo.modelID)
+            }
+
+        case .coreMLZip:
+            retryCountByTaskKey[taskKey(modelID: taskInfo.modelID, kind: .coreMLZip)] = 0
+            pending.coreMLZipTempURL = tempURL
+            pendingInstallByModelID[taskInfo.modelID] = pending
+            finalizeInstall(for: taskInfo.modelID)
+        }
+    }
+
+    private func finalizeInstall(for modelID: String) {
+        guard let pending = pendingInstallByModelID.removeValue(forKey: modelID) else {
+            return
+        }
+
+        installStateByModelID[modelID] = .installing
+
+        Task.detached(priority: .userInitiated) { [pending] in
+            do {
+                try Self.performInstall(pending: pending)
+                await MainActor.run {
+                    WhisperModelManager.shared.installStateByModelID[modelID] = .installed
+                    WhisperModelManager.shared.refreshInstallStates()
+                }
+            } catch {
+                await MainActor.run {
+                    WhisperModelManager.shared.installStateByModelID[modelID] = .failed(message: error.localizedDescription)
+                    WhisperModelManager.shared.refreshInstallStates()
+                }
+            }
+        }
+    }
+
+    private static func performInstall(pending: PendingInstall) throws {
+        let fm = FileManager.default
+        let modelsDir = try modelsDirectoryURL()
+
+        guard let ggmlTempURL = pending.ggmlTempURL else {
+            throw NSError(domain: "WhisperModelManager", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Model file was not downloaded"])
+        }
+
+        if let expectedSHA1 = pending.model.ggmlSHA1, !expectedSHA1.isEmpty {
+            let sha = try sha1Hex(of: ggmlTempURL)
+            guard sha.caseInsensitiveCompare(expectedSHA1) == .orderedSame else {
+                try? fm.removeItem(at: ggmlTempURL)
+                throw NSError(domain: "WhisperModelManager", code: 1002, userInfo: [NSLocalizedDescriptionKey: "Checksum mismatch for \(pending.model.displayName)"])
+            }
+        }
+
+        let finalModelURL = modelsDir.appendingPathComponent(pending.model.ggmlFilename)
+        try replaceItem(at: finalModelURL, with: ggmlTempURL)
+
+        if let coreMLZipURL = pending.coreMLZipTempURL {
+            let extractionRoot = fm.temporaryDirectory.appendingPathComponent("keyscribe-whisper-coreml-\(UUID().uuidString)")
+            try fm.createDirectory(at: extractionRoot, withIntermediateDirectories: true)
+            defer {
+                try? fm.removeItem(at: extractionRoot)
+                try? fm.removeItem(at: coreMLZipURL)
+            }
+
+            try unzipArchive(from: coreMLZipURL, to: extractionRoot)
+
+            guard let extractedModelDirectory = findDirectory(
+                named: pending.model.coreMLDirectoryName,
+                under: extractionRoot
+            ) else {
+                throw NSError(domain: "WhisperModelManager", code: 1003, userInfo: [NSLocalizedDescriptionKey: "Core ML bundle is missing expected folder"])
+            }
+
+            let finalCoreMLURL = modelsDir.appendingPathComponent(pending.model.coreMLDirectoryName, isDirectory: true)
+            try replaceItem(at: finalCoreMLURL, with: extractedModelDirectory)
+        }
+    }
+
+    private static func modelsDirectoryURL() throws -> URL {
+        let appSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+
+        let keyScribeDirectory = appSupport
+            .appendingPathComponent("KeyScribe", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: keyScribeDirectory, withIntermediateDirectories: true)
+        return keyScribeDirectory
+    }
+
+    private func modelFileURL(for modelID: String) -> URL {
+        let base = (try? Self.modelsDirectoryURL()) ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/KeyScribe/Models", isDirectory: true)
+        return base.appendingPathComponent("ggml-\(modelID).bin")
+    }
+
+    private func coreMLDirectoryURL(for modelID: String) -> URL {
+        let base = (try? Self.modelsDirectoryURL()) ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/KeyScribe/Models", isDirectory: true)
+        return base.appendingPathComponent("ggml-\(modelID)-encoder.mlmodelc", isDirectory: true)
+    }
+
+    private func taskKey(modelID: String, kind: DownloadAssetKind) -> String {
+        let kindLabel: String
+        switch kind {
+        case .ggml:
+            kindLabel = "ggml"
+        case .coreMLZip:
+            kindLabel = "coreml"
+        }
+        return "\(modelID)|\(kindLabel)"
+    }
+
+    private func isRetryableNetworkError(_ error: NSError) -> Bool {
+        guard error.domain == NSURLErrorDomain else { return false }
+        return [
+            NSURLErrorTimedOut,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorCannotFindHost,
+            NSURLErrorDNSLookupFailed,
+            NSURLErrorInternationalRoamingOff,
+            NSURLErrorDataNotAllowed,
+            NSURLErrorCallIsActive
+        ].contains(error.code)
+    }
+
+    private static func replaceItem(at destinationURL: URL, with sourceURL: URL) throws {
+        let fm = FileManager.default
+
+        if fm.fileExists(atPath: destinationURL.path) {
+            _ = try fm.replaceItemAt(destinationURL, withItemAt: sourceURL)
+        } else {
+            try fm.moveItem(at: sourceURL, to: destinationURL)
+        }
+    }
+
+    private static func sha1Hex(of fileURL: URL) throws -> String {
+        let data = try Data(contentsOf: fileURL)
+        let digest = Insecure.SHA1.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func unzipArchive(from archiveURL: URL, to destinationURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-o", archiveURL.path, "-d", destinationURL.path]
+
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "WhisperModelManager",
+                code: 1004,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to unzip Core ML bundle: \(stderrText)"]
+            )
+        }
+    }
+
+    private static func findDirectory(named targetName: String, under rootURL: URL) -> URL? {
+        let enumerator = FileManager.default.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        while let next = enumerator?.nextObject() as? URL {
+            guard next.lastPathComponent == targetName else { continue }
+            if (try? next.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+                return next
+            }
+        }
+
+        return nil
+    }
+}
+
+extension WhisperModelManager: URLSessionDownloadDelegate {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        Task { @MainActor in
+            guard let taskInfo = self.taskInfoByTaskID[downloadTask.taskIdentifier],
+                  let pending = self.pendingInstallByModelID[taskInfo.modelID],
+                  totalBytesExpectedToWrite > 0
+            else {
+                return
+            }
+
+            let assetProgress = max(0, min(1, Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)))
+            let overallProgress: Double
+
+            switch taskInfo.kind {
+            case .ggml:
+                if pending.includeCoreML, pending.model.coreMLDownloadURL != nil {
+                    overallProgress = assetProgress * 0.7
+                } else {
+                    overallProgress = assetProgress
+                }
+
+            case .coreMLZip:
+                overallProgress = 0.7 + (assetProgress * 0.3)
+            }
+
+            self.installStateByModelID[taskInfo.modelID] = .downloading(progress: max(0, min(1, overallProgress)))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        if Thread.isMainThread {
+            self.handleDownloadFinished(taskIdentifier: downloadTask.taskIdentifier, temporaryLocation: location)
+        } else {
+            // Move/capture the temporary file before this delegate callback returns,
+            // otherwise the system may remove it and staging fails.
+            DispatchQueue.main.sync {
+                self.handleDownloadFinished(taskIdentifier: downloadTask.taskIdentifier, temporaryLocation: location)
+            }
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        Task { @MainActor in
+            guard let taskInfo = self.taskInfoByTaskID.removeValue(forKey: task.taskIdentifier) else {
+                return
+            }
+
+            guard let error else {
+                return
+            }
+
+            let nsError = error as NSError
+            if nsError.code == NSURLErrorCancelled {
+                self.pendingInstallByModelID.removeValue(forKey: taskInfo.modelID)
+                self.installStateByModelID[taskInfo.modelID] = self.hasInstalledModel(id: taskInfo.modelID)
+                    ? .installed
+                    : .notInstalled
+                return
+            }
+
+            let retryKey = self.taskKey(modelID: taskInfo.modelID, kind: taskInfo.kind)
+            let currentRetryCount = self.retryCountByTaskKey[retryKey, default: 0]
+            let hasBaseModelStaged = self.pendingInstallByModelID[taskInfo.modelID]?.ggmlTempURL != nil
+
+            if self.pendingInstallByModelID[taskInfo.modelID] != nil,
+               self.isRetryableNetworkError(nsError),
+               currentRetryCount < self.maxRetryCount {
+                self.retryCountByTaskKey[retryKey] = currentRetryCount + 1
+                self.installStateByModelID[taskInfo.modelID] = .downloading(progress: 0)
+                self.startDownload(for: taskInfo.modelID, kind: taskInfo.kind)
+                return
+            }
+
+            // Core ML is optional: if the base ggml model is already staged, finish install without Core ML.
+            if taskInfo.kind == .coreMLZip, hasBaseModelStaged {
+                self.finalizeInstall(for: taskInfo.modelID)
+                return
+            }
+
+            self.pendingInstallByModelID.removeValue(forKey: taskInfo.modelID)
+
+            if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorTimedOut {
+                self.installStateByModelID[taskInfo.modelID] = .failed(message: "Download timed out. Check network and retry.")
+            } else {
+                self.installStateByModelID[taskInfo.modelID] = .failed(message: error.localizedDescription)
+            }
+        }
+    }
+}

--- a/Sources/KeyScribe/Services/WhisperTranscriber.swift
+++ b/Sources/KeyScribe/Services/WhisperTranscriber.swift
@@ -1,0 +1,620 @@
+import AVFoundation
+import CoreAudio
+import Foundation
+
+#if canImport(whisper)
+import whisper
+
+final class WhisperTranscriber: NSObject {
+    var onFinalText: ((String) -> Void)?
+    var onStatusUpdate: ((String) -> Void)?
+    var onAudioLevel: ((Float) -> Void)?
+    var onRecordingStateChange: ((Bool) -> Void)?
+
+    private let audioEngine = AVAudioEngine()
+    private let sampleQueue = DispatchQueue(label: "KeyScribe.WhisperSamples")
+    private var transcriptionQueue = DispatchQueue(label: "KeyScribe.WhisperTranscription")
+    private let finalizeWatchdogTimeoutSeconds: TimeInterval = 180
+
+    private var granted = false
+    private(set) var isRecording = false
+    private var isTranscribing = false
+    private var previousDefaultInputDevice: AudioDeviceID?
+    private var pcmSamples: [Float] = []
+
+    private var autoDetectMicrophone = true
+    private var selectedMicrophoneUID = ""
+
+    private var selectedModelID = ""
+    private var useCoreML = true
+    private var finalizeDelaySeconds: TimeInterval = 0.35
+    private var biasPhrases: [String] = []
+    private var pendingStopWorkItem: DispatchWorkItem?
+    private var activeFinalizeRunID: String?
+
+    private let modelManager = WhisperModelManager.shared
+
+    override init() {
+        super.init()
+    }
+
+    func requestPermissions(promptIfNeeded: Bool = true) {
+        if Thread.isMainThread {
+            requestMicrophonePermissionOnMain(promptIfNeeded: promptIfNeeded)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.requestMicrophonePermissionOnMain(promptIfNeeded: promptIfNeeded)
+            }
+        }
+    }
+
+    func applyMicrophoneSettings(autoDetect: Bool, microphoneUID: String) {
+        if Thread.isMainThread {
+            autoDetectMicrophone = autoDetect
+            selectedMicrophoneUID = microphoneUID
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.autoDetectMicrophone = autoDetect
+                self?.selectedMicrophoneUID = microphoneUID
+            }
+        }
+    }
+
+    func applyWhisperSettings(selectedModelID: String, useCoreML: Bool) {
+        if Thread.isMainThread {
+            self.selectedModelID = selectedModelID
+            self.useCoreML = useCoreML
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.selectedModelID = selectedModelID
+                self?.useCoreML = useCoreML
+            }
+        }
+    }
+
+    func applyBiasPhrases(_ phrases: [String]) {
+        if Thread.isMainThread {
+            biasPhrases = phrases
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.biasPhrases = phrases
+            }
+        }
+    }
+
+    func applyFinalizeDelaySeconds(_ delaySeconds: TimeInterval) {
+        if Thread.isMainThread {
+            finalizeDelaySeconds = RecognitionTuning.clampedFinalizeDelay(delaySeconds)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.finalizeDelaySeconds = RecognitionTuning.clampedFinalizeDelay(delaySeconds)
+            }
+        }
+    }
+
+    @discardableResult
+    func startRecording() -> Bool {
+        if Thread.isMainThread {
+            return startRecordingOnMain()
+        }
+
+        return DispatchQueue.main.sync {
+            startRecordingOnMain()
+        }
+    }
+
+    func stopRecording(emitFinalText: Bool = true) {
+        if Thread.isMainThread {
+            stopRecordingOnMain(emitFinalText: emitFinalText)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.stopRecordingOnMain(emitFinalText: emitFinalText)
+            }
+        }
+    }
+
+    private func requestMicrophonePermissionOnMain(promptIfNeeded: Bool) {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            granted = true
+            updateStatus("Permissions ready")
+
+        case .notDetermined:
+            guard promptIfNeeded else {
+                granted = false
+                return
+            }
+
+            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if granted {
+                        self.granted = true
+                        self.updateStatus("Permissions ready")
+                    } else {
+                        self.granted = false
+                        self.updateStatus("Microphone permission not granted")
+                    }
+                }
+            }
+
+        default:
+            granted = false
+            updateStatus("Microphone permission not granted")
+        }
+    }
+
+    @discardableResult
+    private func startRecordingOnMain() -> Bool {
+        guard granted else {
+            requestMicrophonePermissionOnMain(promptIfNeeded: true)
+            updateStatus("Permissions missing")
+            CrashReporter.logWarning("Whisper start blocked: microphone permissions missing")
+            return false
+        }
+
+        guard !isRecording, !isTranscribing else {
+            if isRecording {
+                updateStatus("Whisper is already recording")
+                CrashReporter.logInfo("Whisper start ignored: recording already active")
+            } else {
+                updateStatus("Whisper is finalizing the previous segment. Wait for Ready, then try again.")
+                CrashReporter.logWarning("Whisper start blocked: transcription finalization still running")
+            }
+            return false
+        }
+
+        guard modelManager.hasInstalledModel(id: selectedModelID) else {
+            updateStatus("Whisper model not installed. Open Settings > Recognition to download one")
+            CrashReporter.logWarning("Whisper start blocked: selected model is not installed (\(selectedModelID))")
+            return false
+        }
+
+        applyMicSelection()
+
+        pendingStopWorkItem?.cancel()
+        pendingStopWorkItem = nil
+        pcmSamples = []
+        isRecording = true
+        onRecordingStateChange?(true)
+
+        let inputNode = audioEngine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+
+        guard let targetFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
+              let converter = AVAudioConverter(from: inputFormat, to: targetFormat)
+        else {
+            updateStatus("Audio converter setup failed")
+            CrashReporter.logError("Whisper audio converter setup failed")
+            restoreMicSelection()
+            isRecording = false
+            onRecordingStateChange?(false)
+            return false
+        }
+
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+
+            let level = self.normalizedAudioLevel(from: buffer)
+            DispatchQueue.main.async {
+                self.onAudioLevel?(level)
+            }
+
+            guard let convertedBuffer = self.convert(buffer: buffer, converter: converter, outputFormat: targetFormat) else {
+                return
+            }
+
+            let frameCount = Int(convertedBuffer.frameLength)
+            guard frameCount > 0, let channelData = convertedBuffer.floatChannelData?.pointee else {
+                return
+            }
+
+            let copied = Array(UnsafeBufferPointer(start: channelData, count: frameCount))
+            self.sampleQueue.async {
+                self.pcmSamples.append(contentsOf: copied)
+            }
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            updateStatus("Listening…")
+            CrashReporter.logInfo(
+                "Whisper recording started model=\(selectedModelID) coreml=\(useCoreML) autoMic=\(autoDetectMicrophone)"
+            )
+            return true
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            audioEngine.stop()
+            onAudioLevel?(0)
+            restoreMicSelection()
+            isRecording = false
+            onRecordingStateChange?(false)
+            updateStatus("Audio setup failed: \(error.localizedDescription)")
+            CrashReporter.logError("Whisper audio setup failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func stopRecordingOnMain(emitFinalText: Bool) {
+        if pendingStopWorkItem != nil {
+            updateStatus("Finalizing already requested")
+            return
+        }
+
+        guard isRecording || isTranscribing else {
+            onAudioLevel?(0)
+            onRecordingStateChange?(false)
+            return
+        }
+
+        if isTranscribing && !isRecording {
+            updateStatus("Finalizing in progress")
+            return
+        }
+
+        if isRecording {
+            let delay = finalizeDelaySeconds
+            if delay > 0 {
+                updateStatus("Finalizing…")
+                let workItem = DispatchWorkItem { [weak self] in
+                    self?.completeStopRecording(emitFinalText: emitFinalText)
+                }
+                pendingStopWorkItem = workItem
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+                return
+            }
+        }
+
+        completeStopRecording(emitFinalText: emitFinalText)
+    }
+
+    private func completeStopRecording(emitFinalText: Bool) {
+        pendingStopWorkItem = nil
+
+        guard let modelURL = modelManager.installedModelURL(for: selectedModelID) else {
+            isRecording = false
+            isTranscribing = false
+            onRecordingStateChange?(false)
+            onAudioLevel?(0)
+            restoreMicSelection()
+            updateStatus("Whisper model not installed. Open Settings > Recognition to download one")
+            CrashReporter.logWarning("Whisper finalize blocked: selected model disappeared (\(selectedModelID))")
+            return
+        }
+
+        let coreMLDirectoryURL = useCoreML ? modelManager.installedCoreMLDirectoryURL(for: selectedModelID) : nil
+        let shouldForceCPUForStability = selectedModelID.hasPrefix("small") || selectedModelID.hasPrefix("medium")
+
+        if isRecording {
+            isRecording = false
+            onRecordingStateChange?(false)
+
+            audioEngine.inputNode.removeTap(onBus: 0)
+            audioEngine.stop()
+            onAudioLevel?(0)
+        }
+
+        var samplesToTranscribe: [Float] = []
+        sampleQueue.sync {
+            samplesToTranscribe = pcmSamples
+            pcmSamples.removeAll(keepingCapacity: false)
+        }
+
+        guard !samplesToTranscribe.isEmpty else {
+            isTranscribing = false
+            restoreMicSelection()
+            updateStatus("Ready")
+            CrashReporter.logInfo("Whisper finalize skipped: no audio samples captured")
+            return
+        }
+
+        isTranscribing = true
+        if shouldForceCPUForStability {
+            updateStatus("Finalizing… (small/medium can take up to ~2 minutes on CPU)")
+        } else {
+            updateStatus("Finalizing…")
+        }
+
+        let threadCount = max(1, min(8, ProcessInfo.processInfo.activeProcessorCount - 2))
+        let shouldUseCoreML = coreMLDirectoryURL != nil && useCoreML && !shouldForceCPUForStability
+        let prompt = RecognitionTuning.whisperInitialPrompt(from: biasPhrases)
+        let runID = UUID().uuidString
+        let selectedModelID = self.selectedModelID
+        let sampleCount = samplesToTranscribe.count
+        let startTime = Date()
+        activeFinalizeRunID = runID
+
+        if shouldForceCPUForStability, useCoreML {
+            CrashReporter.logWarning("Whisper Core ML disabled for model=\(selectedModelID) due stability guard")
+        }
+
+        CrashReporter.logInfo(
+            "Whisper finalize started run=\(runID) model=\(selectedModelID) samples=\(sampleCount) threads=\(threadCount) coreml=\(shouldUseCoreML)"
+        )
+
+        let stuckRunWatchdog = DispatchWorkItem { [weak self] in
+            guard let self, self.isTranscribing, self.activeFinalizeRunID == runID else { return }
+            CrashReporter.logWarning(
+                "Whisper finalize still running after \(Int(self.finalizeWatchdogTimeoutSeconds))s run=\(runID) model=\(selectedModelID) samples=\(sampleCount)"
+            )
+            self.activeFinalizeRunID = nil
+            self.isTranscribing = false
+            self.restoreMicSelection()
+            self.transcriptionQueue = DispatchQueue(label: "KeyScribe.WhisperTranscription")
+            self.updateStatus("Whisper finalize timed out and was reset. Try again.")
+            CrashReporter.logError("Whisper finalize timed out and transcription queue was reset run=\(runID) model=\(selectedModelID)")
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + finalizeWatchdogTimeoutSeconds, execute: stuckRunWatchdog)
+
+        transcriptionQueue.async { [weak self] in
+            guard let self else { return }
+
+            let result = self.transcribe(
+                samples: samplesToTranscribe,
+                modelURL: modelURL,
+                language: "en",
+                threadCount: threadCount,
+                useCoreML: shouldUseCoreML,
+                prompt: prompt
+            )
+
+            DispatchQueue.main.async {
+                stuckRunWatchdog.cancel()
+
+                guard self.activeFinalizeRunID == runID else {
+                    CrashReporter.logWarning(
+                        "Whisper finalize completion ignored (stale run) run=\(runID) model=\(selectedModelID)"
+                    )
+                    return
+                }
+
+                self.activeFinalizeRunID = nil
+                self.isTranscribing = false
+                self.restoreMicSelection()
+
+                let elapsedSeconds = Date().timeIntervalSince(startTime)
+                let elapsedText = String(format: "%.2f", elapsedSeconds)
+
+                switch result {
+                case let .success(text):
+                    if shouldUseCoreML {
+                        self.updateStatus("Ready")
+                    } else if self.useCoreML, coreMLDirectoryURL == nil {
+                        self.updateStatus("Ready (Core ML encoder not installed for this model)")
+                    } else {
+                        self.updateStatus("Ready")
+                    }
+
+                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    CrashReporter.logInfo(
+                        "Whisper finalize completed run=\(runID) model=\(selectedModelID) duration=\(elapsedText)s outputChars=\(trimmed.count)"
+                    )
+                    if emitFinalText, !trimmed.isEmpty {
+                        self.onFinalText?(trimmed)
+                    }
+
+                case let .failure(error):
+                    self.updateStatus("Whisper error: \(error.localizedDescription)")
+                    CrashReporter.logError(
+                        "Whisper finalize failed run=\(runID) model=\(selectedModelID) duration=\(elapsedText)s error=\(error.localizedDescription)"
+                    )
+                }
+            }
+        }
+    }
+
+    private func transcribe(
+        samples: [Float],
+        modelURL: URL,
+        language: String,
+        threadCount: Int,
+        useCoreML: Bool,
+        prompt: String?
+    ) -> Result<String, Error> {
+        var contextParams = whisper_context_default_params()
+        contextParams.use_gpu = useCoreML
+        // flash_attn has shown instability on some small/medium runs in production.
+        contextParams.flash_attn = false
+
+        guard let ctx = whisper_init_from_file_with_params(modelURL.path, contextParams) else {
+            return .failure(NSError(domain: "WhisperTranscriber", code: 2001, userInfo: [NSLocalizedDescriptionKey: "Failed to load whisper model"]))
+        }
+        defer {
+            whisper_free(ctx)
+        }
+
+        var params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
+        params.print_realtime = false
+        params.print_progress = false
+        params.print_timestamps = false
+        params.print_special = false
+        params.translate = false
+        params.no_context = true
+        params.single_segment = false
+        params.n_threads = Int32(max(1, threadCount))
+        params.offset_ms = 0
+
+        let runResult: Int32 = language.withCString { languageCString in
+            params.language = languageCString
+            params.carry_initial_prompt = false
+
+            let execute = {
+                samples.withUnsafeBufferPointer { buffer in
+                    whisper_full(ctx, params, buffer.baseAddress, Int32(samples.count))
+                }
+            }
+
+            if let prompt, !prompt.isEmpty {
+                return prompt.withCString { promptCString in
+                    params.initial_prompt = promptCString
+                    return execute()
+                }
+            } else {
+                params.initial_prompt = nil
+                return execute()
+            }
+        }
+
+        guard runResult == 0 else {
+            return .failure(NSError(domain: "WhisperTranscriber", code: 2002, userInfo: [NSLocalizedDescriptionKey: "whisper_full failed"]))
+        }
+
+        let segmentCount = whisper_full_n_segments(ctx)
+        var transcript = ""
+        transcript.reserveCapacity(512)
+
+        for i in 0..<segmentCount {
+            guard let raw = whisper_full_get_segment_text(ctx, i) else { continue }
+            transcript += String(cString: raw)
+        }
+
+        return .success(transcript)
+    }
+
+    private func convert(
+        buffer: AVAudioPCMBuffer,
+        converter: AVAudioConverter,
+        outputFormat: AVAudioFormat
+    ) -> AVAudioPCMBuffer? {
+        let ratio = outputFormat.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 32
+
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: capacity) else {
+            return nil
+        }
+
+        var conversionError: NSError?
+        var didProvideInput = false
+
+        let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+            if didProvideInput {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            didProvideInput = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        converter.convert(to: outputBuffer, error: &conversionError, withInputFrom: inputBlock)
+
+        if conversionError != nil {
+            return nil
+        }
+
+        return outputBuffer
+    }
+
+    private func updateStatus(_ message: String) {
+        if Thread.isMainThread {
+            onStatusUpdate?(message)
+        } else {
+            DispatchQueue.main.async {
+                self.onStatusUpdate?(message)
+            }
+        }
+    }
+
+    private func applyMicSelection() {
+        guard !autoDetectMicrophone else {
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        guard !selectedMicrophoneUID.isEmpty else {
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        guard let selectedDeviceID = MicrophoneManager.deviceID(forUID: selectedMicrophoneUID) else {
+            updateStatus("Selected microphone no longer available")
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        guard let currentDefault = MicrophoneManager.defaultInputDeviceID() else {
+            updateStatus("Unable to read default microphone")
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        if currentDefault == selectedDeviceID {
+            previousDefaultInputDevice = nil
+            return
+        }
+
+        let changed = MicrophoneManager.setDefaultInput(deviceID: selectedDeviceID)
+        if changed {
+            previousDefaultInputDevice = currentDefault
+        } else {
+            updateStatus("Could not switch microphone")
+            previousDefaultInputDevice = nil
+        }
+    }
+
+    private func restoreMicSelection() {
+        guard let previous = previousDefaultInputDevice else { return }
+        _ = MicrophoneManager.setDefaultInput(deviceID: previous)
+        previousDefaultInputDevice = nil
+    }
+
+    private func normalizedAudioLevel(from buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData else {
+            return 0
+        }
+
+        let channelSamples = channelData.pointee
+        let frameCount = Int(buffer.frameLength)
+        guard frameCount > 0 else { return 0 }
+
+        var sum: Float = 0
+        for index in 0..<frameCount {
+            let sample = channelSamples[index]
+            sum += sample * sample
+        }
+
+        let meanSquare = sum / Float(frameCount)
+        let rms = sqrtf(max(meanSquare, 1e-12))
+        let db = 20 * log10f(rms)
+        let normalized = (db + 70) / 70
+        return max(0, min(1, normalized))
+    }
+}
+
+#else
+
+final class WhisperTranscriber: NSObject {
+    var onFinalText: ((String) -> Void)?
+    var onStatusUpdate: ((String) -> Void)?
+    var onAudioLevel: ((Float) -> Void)?
+    var onRecordingStateChange: ((Bool) -> Void)?
+
+    func requestPermissions(promptIfNeeded: Bool = true) {
+        if promptIfNeeded {
+            onStatusUpdate?("Whisper framework is unavailable")
+        }
+    }
+
+    func applyMicrophoneSettings(autoDetect: Bool, microphoneUID: String) {}
+
+    func applyWhisperSettings(selectedModelID: String, useCoreML: Bool) {}
+
+    func applyBiasPhrases(_ phrases: [String]) {}
+
+    func applyFinalizeDelaySeconds(_ delaySeconds: TimeInterval) {}
+
+    @discardableResult
+    func startRecording() -> Bool {
+        onStatusUpdate?("Whisper framework is unavailable")
+        return false
+    }
+
+    func stopRecording(emitFinalText: Bool = true) {
+        onRecordingStateChange?(false)
+        onAudioLevel?(0)
+    }
+}
+
+#endif

--- a/Sources/KeyScribe/Support/AppWindowCoordinator.swift
+++ b/Sources/KeyScribe/Support/AppWindowCoordinator.swift
@@ -7,6 +7,8 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     private let settingsMinimumSize = NSSize(width: 820, height: 560)
     private let historyDefaultSize = NSSize(width: 620, height: 500)
     private let historyMinimumSize = NSSize(width: 520, height: 360)
+    private let onboardingDefaultSize = NSSize(width: 620, height: 460)
+    private let onboardingMinimumSize = NSSize(width: 560, height: 420)
 
     private let settings: SettingsStore
     private let transcriptHistory: TranscriptHistoryStore
@@ -15,7 +17,9 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
 
     private var settingsWindowController: NSWindowController?
     private var historyWindowController: NSWindowController?
+    private var onboardingWindowController: NSWindowController?
     private var historyTargetApplication: NSRunningApplication?
+    private var onboardingCompletion: (() -> Void)?
 
     init(
         settings: SettingsStore,
@@ -77,6 +81,63 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         onStatusUpdate(.ready)
     }
 
+    func openPermissionOnboardingWindow(onComplete: @escaping () -> Void) {
+        onboardingCompletion = onComplete
+
+        if onboardingWindowController == nil {
+            let onboardingView = PermissionOnboardingView(onComplete: { [weak self] in
+                guard let self else { return }
+                self.onboardingCompletion?()
+            })
+            .environmentObject(settings)
+
+            let hostingController = NSHostingController(rootView: onboardingView)
+            let window = NSWindow(
+                contentRect: NSRect(origin: .zero, size: onboardingDefaultSize),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+                backing: .buffered,
+                defer: false
+            )
+
+            window.title = "KeyScribe Permission Setup"
+            window.titleVisibility = .hidden
+            window.titlebarAppearsTransparent = true
+            window.toolbarStyle = .unifiedCompact
+            window.isMovableByWindowBackground = true
+            window.contentViewController = hostingController
+            window.hidesOnDeactivate = false
+            window.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+            window.isReleasedWhenClosed = false
+            window.minSize = onboardingMinimumSize
+            centerWindowOnActiveScreen(window)
+            window.delegate = self
+
+            onboardingWindowController = NSWindowController(window: window)
+        }
+
+        guard let window = onboardingWindowController?.window else {
+            onStatusUpdate(.message("Could not open permission setup"))
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        onboardingWindowController?.showWindow(nil)
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        if window.frame.width < onboardingMinimumSize.width || window.frame.height < onboardingMinimumSize.height {
+            window.setContentSize(onboardingDefaultSize)
+        }
+        centerWindowOnActiveScreen(window)
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func closePermissionOnboardingWindow() {
+        onboardingWindowController?.close()
+        onboardingWindowController = nil
+    }
+
     func openHistoryWindow() {
         if let frontmost = NSWorkspace.shared.frontmostApplication,
            frontmost.processIdentifier != ProcessInfo.processInfo.processIdentifier {
@@ -136,6 +197,8 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     }
 
     func closeAllWindows() {
+        onboardingWindowController?.close()
+        onboardingWindowController = nil
         settingsWindowController?.close()
         settingsWindowController = nil
         historyWindowController?.close()
@@ -148,6 +211,8 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
                 settingsWindowController = nil
             } else if closingWindow === historyWindowController?.window {
                 historyWindowController = nil
+            } else if closingWindow === onboardingWindowController?.window {
+                onboardingWindowController = nil
             }
         }
     }

--- a/Sources/KeyScribe/Support/PermissionCenter.swift
+++ b/Sources/KeyScribe/Support/PermissionCenter.swift
@@ -1,0 +1,85 @@
+import AppKit
+import AVFoundation
+import Speech
+
+@MainActor
+enum PermissionCenter {
+    struct Snapshot {
+        let accessibilityGranted: Bool
+        let microphoneGranted: Bool
+        let speechRecognitionGranted: Bool
+        let speechRecognitionRequired: Bool
+
+        var allRequiredGranted: Bool {
+            accessibilityGranted && microphoneGranted && (!speechRecognitionRequired || speechRecognitionGranted)
+        }
+    }
+
+    static func snapshot(using settings: SettingsStore) -> Snapshot {
+        settings.refreshAccessibilityStatus(prompt: false)
+        return Snapshot(
+            accessibilityGranted: settings.accessibilityTrusted,
+            microphoneGranted: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
+            speechRecognitionGranted: SFSpeechRecognizer.authorizationStatus() == .authorized,
+            speechRecognitionRequired: settings.transcriptionEngine == .appleSpeech
+        )
+    }
+
+    static func requestAccessibilityPermission(using settings: SettingsStore, promptIfNeeded: Bool = true) {
+        settings.refreshAccessibilityStatus(prompt: promptIfNeeded)
+        if !settings.accessibilityTrusted {
+            openPrivacySettingsPane(query: "Privacy_Accessibility")
+        }
+    }
+
+    static func requestMicrophonePermission(openSettingsIfDenied: Bool = false) {
+        let status = AVCaptureDevice.authorizationStatus(for: .audio)
+        if status == .authorized { return }
+
+        // Always attempt requestAccess — on a fresh install or after tccutil reset
+        // the status may be .notDetermined or even .denied before the app has ever
+        // triggered the system prompt with the current code signature.
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            guard !granted, openSettingsIfDenied else { return }
+            DispatchQueue.main.async { openPrivacySettingsPane(query: "Privacy_Microphone") }
+        }
+    }
+
+    static func requestSpeechRecognitionPermission(openSettingsIfDenied: Bool = false) {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            return
+        case .notDetermined:
+            SFSpeechRecognizer.requestAuthorization { status in
+                guard status != .authorized, openSettingsIfDenied else { return }
+                DispatchQueue.main.async { openPrivacySettingsPane(query: "Privacy_SpeechRecognition") }
+            }
+        case .denied, .restricted:
+            if openSettingsIfDenied {
+                openPrivacySettingsPane(query: "Privacy_SpeechRecognition")
+            }
+        @unknown default:
+            if openSettingsIfDenied {
+                openPrivacySettingsPane(query: "Privacy_SpeechRecognition")
+            }
+        }
+    }
+
+    static func openPrivacySettingsPane(query: String) {
+        let urlStrings = [
+            "x-apple.systempreferences:com.apple.preference.security?\(query)",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy",
+            "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension"
+        ]
+
+        for urlString in urlStrings {
+            guard let url = URL(string: urlString) else { continue }
+            if NSWorkspace.shared.open(url) {
+                return
+            }
+        }
+
+        let legacySecurityPaneURL = URL(fileURLWithPath: "/System/Library/PreferencePanes/Security.prefPane")
+        _ = NSWorkspace.shared.open(legacySecurityPaneURL)
+    }
+}

--- a/Sources/KeyScribe/Support/ShortcutValidation.swift
+++ b/Sources/KeyScribe/Support/ShortcutValidation.swift
@@ -4,6 +4,88 @@ import Foundation
 enum ShortcutValidation {
     static let supportedModifierFlags: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
     static let modifierOnlyKeyCodes: Set<UInt16> = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+    static let keyNames: [UInt16: String] = [
+        0: "A",
+        1: "S",
+        2: "D",
+        3: "F",
+        4: "H",
+        5: "G",
+        6: "Z",
+        7: "X",
+        8: "C",
+        9: "V",
+        11: "B",
+        12: "Q",
+        13: "W",
+        14: "E",
+        15: "R",
+        16: "Y",
+        17: "T",
+        18: "1",
+        19: "2",
+        20: "3",
+        21: "4",
+        22: "6",
+        23: "5",
+        24: "=",
+        25: "9",
+        26: "7",
+        27: "-",
+        28: "8",
+        29: "0",
+        30: "]",
+        31: "O",
+        32: "U",
+        33: "[",
+        34: "I",
+        35: "P",
+        36: "Return",
+        37: "L",
+        38: "J",
+        39: "'",
+        40: "K",
+        41: ";",
+        42: "\\",
+        43: ",",
+        44: "/",
+        45: "N",
+        46: "M",
+        47: ".",
+        48: "`",
+        49: "Space",
+        50: "`",
+        51: "Delete",
+        53: "Esc",
+        122: "F1",
+        120: "F2",
+        99: "F3",
+        118: "F4",
+        96: "F5",
+        97: "F6",
+        98: "F7",
+        100: "F8",
+        101: "F9",
+        109: "F10",
+        103: "F11",
+        111: "F12",
+        105: "F13",
+        107: "F14",
+        113: "F15",
+        106: "F16",
+        64: "F17",
+        79: "F18",
+        80: "F19",
+        90: "F20",
+        63: "Fn"
+    ]
+    static let manualAssignableKeyCodes: [UInt16] = [
+        49, 36, 51, 53,
+        0, 11, 8, 2, 14, 3, 5, 4, 34, 38, 40, 37, 46, 45, 31, 35, 12, 15, 1, 17, 32, 9, 13, 7, 16, 6,
+        18, 19, 20, 21, 23, 22, 26, 28, 25, 29,
+        24, 27, 33, 30, 41, 39, 43, 47, 44, 42,
+        122, 120, 99, 118, 96, 97, 98, 100, 101, 109, 103, 111, 105, 107, 113, 106, 64, 79, 80, 90
+    ]
 
     static let defaultKeyCode: UInt16 = 49
     static let defaultModifiers: UInt = NSEvent.ModifierFlags([.command, .option]).rawValue
@@ -35,11 +117,11 @@ enum ShortcutValidation {
         let count = modifierCount(in: flags)
 
         if keyCode == UInt16.max {
-            return (2...3).contains(count)
+            return (2...4).contains(count)
         }
 
         guard !isModifierOnlyKeyCode(keyCode) else { return false }
-        return (1...2).contains(count)
+        return (1...3).contains(count)
     }
 
     static func displaySegments(keyCode: UInt16, modifiersRaw: UInt) -> [String] {
@@ -60,82 +142,6 @@ enum ShortcutValidation {
     }
 
     static func keyName(for code: UInt16) -> String {
-        let names: [UInt16: String] = [
-            0: "A",
-            1: "S",
-            2: "D",
-            3: "F",
-            4: "H",
-            5: "G",
-            6: "Z",
-            7: "X",
-            8: "C",
-            9: "V",
-            11: "B",
-            12: "Q",
-            13: "W",
-            14: "E",
-            15: "R",
-            16: "Y",
-            17: "T",
-            18: "1",
-            19: "2",
-            20: "3",
-            21: "4",
-            22: "6",
-            23: "5",
-            24: "=",
-            25: "9",
-            26: "7",
-            27: "-",
-            28: "8",
-            29: "0",
-            30: "]",
-            31: "O",
-            32: "U",
-            33: "[",
-            34: "I",
-            35: "P",
-            36: "Return",
-            37: "L",
-            38: "J",
-            39: "'",
-            40: "K",
-            41: ";",
-            42: "\\",
-            43: ",",
-            44: "/",
-            45: "N",
-            46: "M",
-            47: ".",
-            48: "`",
-            49: "Space",
-            50: "`",
-            51: "Delete",
-            53: "Esc",
-            122: "F1",
-            120: "F2",
-            99: "F3",
-            118: "F4",
-            96: "F5",
-            97: "F6",
-            98: "F7",
-            100: "F8",
-            101: "F9",
-            109: "F10",
-            103: "F11",
-            111: "F12",
-            105: "F13",
-            107: "F14",
-            113: "F15",
-            106: "F16",
-            64: "F17",
-            79: "F18",
-            80: "F19",
-            90: "F20",
-            63: "Fn"
-        ]
-
-        return names[code] ?? "Key \(code)"
+        keyNames[code] ?? "Key \(code)"
     }
 }

--- a/Sources/KeyScribe/Views/PermissionOnboardingView.swift
+++ b/Sources/KeyScribe/Views/PermissionOnboardingView.swift
@@ -1,0 +1,182 @@
+import AppKit
+import SwiftUI
+
+struct PermissionOnboardingView: View {
+    @EnvironmentObject private var settings: SettingsStore
+    let onComplete: () -> Void
+
+    @State private var accessibilityGranted = false
+    @State private var microphoneGranted = false
+    @State private var speechRecognitionGranted = false
+    @State private var speechRecognitionRequired = true
+
+    private var allRequiredGranted: Bool {
+        accessibilityGranted && microphoneGranted && (!speechRecognitionRequired || speechRecognitionGranted)
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(nsColor: .windowBackgroundColor),
+                    Color(nsColor: .underPageBackgroundColor).opacity(0.88)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Finish Permission Setup")
+                        .font(.title2.weight(.semibold))
+                    Text("KeyScribe needs these permissions before dictation and global shortcuts can run.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    permissionRow(
+                        title: "Accessibility",
+                        hint: "Required for global hotkeys and text insertion across apps.",
+                        granted: accessibilityGranted,
+                        required: true,
+                        action: {
+                            PermissionCenter.requestAccessibilityPermission(using: settings, promptIfNeeded: true)
+                            refreshPermissionSnapshot()
+                        }
+                    )
+
+                    permissionRow(
+                        title: "Microphone",
+                        hint: "Required to capture speech.",
+                        granted: microphoneGranted,
+                        required: true,
+                        action: {
+                            PermissionCenter.requestMicrophonePermission(openSettingsIfDenied: true)
+                            refreshPermissionSnapshot()
+                        }
+                    )
+
+                    permissionRow(
+                        title: "Speech Recognition",
+                        hint: speechRecognitionRequired
+                            ? "Required while Apple Speech is selected."
+                            : "Optional while whisper.cpp is selected.",
+                        granted: speechRecognitionGranted,
+                        required: speechRecognitionRequired,
+                        action: {
+                            PermissionCenter.requestSpeechRecognitionPermission(openSettingsIfDenied: true)
+                            refreshPermissionSnapshot()
+                        }
+                    )
+                }
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.primary.opacity(0.05))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+                )
+
+                if !allRequiredGranted {
+                    Text("KeyScribe stays paused until required permissions are granted.")
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.orange)
+                }
+
+                HStack(spacing: 10) {
+                    Button("Check Again") {
+                        refreshPermissionSnapshot()
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("Open Privacy Settings") {
+                        PermissionCenter.openPrivacySettingsPane(query: "Privacy")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Spacer()
+
+                    Button("Continue") {
+                        refreshPermissionSnapshot()
+                        guard allRequiredGranted else { return }
+                        onComplete()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!allRequiredGranted)
+                }
+            }
+            .padding(22)
+            .frame(width: 620, height: 460, alignment: .topLeading)
+        }
+        .onAppear {
+            refreshPermissionSnapshot()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshPermissionSnapshot()
+        }
+        .onReceive(
+            Timer.publish(every: 0.9, on: .main, in: .common).autoconnect()
+        ) { _ in
+            if !allRequiredGranted {
+                refreshPermissionSnapshot()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func permissionRow(
+        title: String,
+        hint: String,
+        granted: Bool,
+        required: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: granted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(granted ? .green : .orange)
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                    if !required {
+                        Text("Optional")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(hint)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if granted {
+                Text("Granted")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.green)
+            } else {
+                Button("Grant") {
+                    action()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func refreshPermissionSnapshot() {
+        let snapshot = PermissionCenter.snapshot(using: settings)
+        accessibilityGranted = snapshot.accessibilityGranted
+        microphoneGranted = snapshot.microphoneGranted
+        speechRecognitionGranted = snapshot.speechRecognitionGranted
+        speechRecognitionRequired = snapshot.speechRecognitionRequired
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,10 @@ for arg in "$@"; do
 done
 
 echo "Building ${APP_NAME} (Release)..."
+if [ ! -d "Vendor/Whisper/whisper.xcframework" ]; then
+    echo "whisper.xcframework not found, downloading framework..."
+    Scripts/update-whisper-framework.sh
+fi
 swift build -c release
 
 echo "Creating macOS App Bundle at ${APP_DIR}..."
@@ -42,6 +46,14 @@ echo "Copying executable..."
 cp ".build/release/${APP_EXECUTABLE}" "$APP_DIR/Contents/MacOS/"
 chmod +x "$APP_DIR/Contents/MacOS/${APP_EXECUTABLE}"
 
+echo "Embedding whisper framework..."
+WHISPER_MACOS_FRAMEWORK="$(find Vendor/Whisper/whisper.xcframework -maxdepth 2 -type d -name whisper.framework | grep 'macos-' | head -n 1 || true)"
+if [ -z "$WHISPER_MACOS_FRAMEWORK" ]; then
+    echo "Failed to locate macOS whisper.framework inside Vendor/Whisper/whisper.xcframework"
+    exit 1
+fi
+cp -R "$WHISPER_MACOS_FRAMEWORK" "$APP_DIR/Contents/MacOS/"
+
 echo "Copying Info.plist and resources..."
 cp Resources/Info.plist "$APP_DIR/Contents/"
 cp Resources/AppIcon.icns "$APP_DIR/Contents/Resources/"
@@ -49,7 +61,7 @@ cp Resources/AppIcon.icns "$APP_DIR/Contents/Resources/"
 echo "Applying code signature..."
 if [ -n "${DEVELOPER_ID:-}" ]; then
     echo "  Signing with Developer ID: $DEVELOPER_ID"
-    codesign --force --deep --options runtime --sign "Developer ID Application: $DEVELOPER_ID" "$APP_DIR"
+    codesign --force --deep --options runtime --entitlements Resources/KeyScribe.entitlements --sign "Developer ID Application: $DEVELOPER_ID" "$APP_DIR"
 else
     echo "  No DEVELOPER_ID set — using ad-hoc signature."
     echo "  (Set DEVELOPER_ID env var for distribution-ready signing)"


### PR DESCRIPTION
## Summary
- Add whisper.cpp transcription engine with model catalog, download manager, and Apple Speech as alternative engine
- Add Developer ID code signing support with audio input entitlements for proper microphone permission prompts
- Modernize settings UI: cleaner sidebar, removed redundant headers, refined cards
- Fix microphone permission flow and improve menu bar icon visibility

## Changes
- **Whisper engine**: WhisperTranscriber, WhisperModelCatalog, WhisperModelManager, adaptive corrections, post-insert correction monitor
- **Signing**: KeyScribe.entitlements with `com.apple.security.device.audio-input`, build.sh updated to pass entitlements during codesign
- **Permissions**: Centralized PermissionCenter, onboarding view, `requestAccess` always called for mic
- **UI**: Settings sidebar uses native macOS styling, heavier menu bar icon weight, wider waveform animation range
- **Build**: Whisper framework auto-download, .gitignore updated for signing artifacts

## Test plan
- [ ] Build with `./build.sh` (ad-hoc) and verify app launches
- [ ] Build with `DEVELOPER_ID="..." ./build.sh` and verify signed DMG
- [ ] Verify microphone permission prompt appears on fresh install
- [ ] Check settings sidebar looks clean in both light and dark mode
- [ ] Verify menu bar icon is visible and animates during recording