### PR TITLE
fix: prevent AVAudio tap format mismatch crash

### DIFF
--- a/Sources/KeyScribe/Services/AppleSpeechTranscriber.swift
+++ b/Sources/KeyScribe/Services/AppleSpeechTranscriber.swift
@@ -246,7 +246,6 @@ final class AppleSpeechTranscriber: NSObject {
         }
 
         let inputNode = audioEngine.inputNode
-        let activeRecognitionRequest = recognitionRequest
 
         // Reset the engine before installing a fresh tap to avoid stale I/O format state
         // when input devices/rates have changed between sessions.
@@ -257,8 +256,8 @@ final class AppleSpeechTranscriber: NSObject {
         // Use nil format so AVAudioEngine uses the node bus format directly.
         // This prevents NSException crashes from tap format mismatches.
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
-            activeRecognitionRequest?.append(buffer)
             guard let self else { return }
+            self.recognitionRequest?.append(buffer)
 
             let audioLevel = self.normalizedAudioLevel(from: buffer)
             DispatchQueue.main.async {

--- a/Sources/KeyScribe/Services/WhisperTranscriber.swift
+++ b/Sources/KeyScribe/Services/WhisperTranscriber.swift
@@ -182,7 +182,7 @@ final class WhisperTranscriber: NSObject {
 
         guard let targetFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)
         else {
-            updateStatus("Audio converter setup failed")
+            updateStatus("Whisper target audio format setup failed")
             CrashReporter.logError("Whisper target audio format setup failed")
             restoreMicSelection()
             isRecording = false
@@ -193,6 +193,8 @@ final class WhisperTranscriber: NSObject {
         // Build converter lazily from the first buffer's real format.
         // This avoids tap install crashes if the active hardware format changes.
         var converter: AVAudioConverter?
+        var converterInputSignature: String?
+        var converterFailureHandled = false
 
         audioEngine.stop()
         audioEngine.reset()
@@ -205,11 +207,28 @@ final class WhisperTranscriber: NSObject {
                 self.onAudioLevel?(level)
             }
 
-            if converter == nil {
+            let inputSignature = "\(buffer.format.sampleRate)-\(buffer.format.channelCount)-\(buffer.format.commonFormat.rawValue)-\(buffer.format.isInterleaved)"
+            if converter == nil || converterInputSignature != inputSignature {
                 converter = AVAudioConverter(from: buffer.format, to: targetFormat)
+                converterInputSignature = inputSignature
+
                 if converter == nil {
-                    CrashReporter.logError("Whisper audio converter setup failed at runtime from format=\(buffer.format)")
+                    if !converterFailureHandled {
+                        converterFailureHandled = true
+                        DispatchQueue.global(qos: .background).async {
+                            CrashReporter.logError("Whisper audio converter setup failed at runtime from format=\(buffer.format)")
+                        }
+                        DispatchQueue.main.async {
+                            self.updateStatus("Audio converter setup failed")
+                            self.stopRecordingOnMain(emitFinalText: false)
+                        }
+                    }
                     return
+                }
+
+                // Input format changed; clear any pre-converted accumulation to avoid mixing formats.
+                self.sampleQueue.async {
+                    self.pcmSamples = []
                 }
             }
 


### PR DESCRIPTION
## Summary
- fix crash in `AppleSpeechTranscriber` when installing AVAudioEngine tap after input format changes
- use `format: nil` for tap install so engine uses bus-native format
- reset AVAudioEngine before re-installing tap to avoid stale I/O state
- apply same hardening to `WhisperTranscriber` with lazy converter init from first buffer format

## Why
Crash logs showed `com.apple.coreaudio.avfaudio` exceptions with:
`Failed to create tap due to format mismatch` in `installTapOnBus`.

## Validation
- pulled latest `main` before patching
- attempted local build (`swift build`), but build is currently blocked by missing `Vendor/Whisper/whisper.xcframework` artifact in this environment

## Notes
This patch is focused on runtime audio tap stability and should remove the NSException path seen in crash reports.
